### PR TITLE
Prefer Docker Compose V1 over V2

### DIFF
--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -1,0 +1,2 @@
+docker_compose_v1_release: "1.29.2"
+docker_compose_v2_release: "v2.2.2"

--- a/ansible/roles/docker/tasks/docker-compose-install-v1.yml
+++ b/ansible/roles/docker/tasks/docker-compose-install-v1.yml
@@ -1,0 +1,20 @@
+---
+# The Ubuntu package of Docker Compose cannot be used as it pulls outdated
+# depdendencies which clash with the Docker Engine installation
+- name: Remove Docker Compose V2
+  ansible.builtin.file:
+    path: "{{ docker_cli_plugins_dir }}/docker-compose"
+    state: absent
+
+- name: Download the Docker Compose V1 executable
+  ansible.builtin.get_url:
+    url: "{{ docker_compose_v1_url }}"
+    dest: "/usr/bin/docker-compose"
+    owner: root
+    group: root
+    mode: 0755
+    checksum: "sha256:{{ lookup('url', docker_compose_v1_digest_url) | regex_search('[0-9a-f]{64}') }}"
+
+- name: Test the installation
+  ansible.builtin.command: docker-compose version
+  changed_when: false

--- a/ansible/roles/docker/tasks/docker-compose-install-v2.yml
+++ b/ansible/roles/docker/tasks/docker-compose-install-v2.yml
@@ -1,15 +1,20 @@
 ---
 # The Ubuntu package of Docker Compose cannot be used as it pulls outdated
 # depdendencies which clash with the Docker Engine installation
-- name: Download the Docker Compose executable
+- name: Remove Docker Compose V1
+  ansible.builtin.file:
+    path: /usr/bin/docker-compose
+    state: absent
+
+- name: Download the Docker Compose v2 executable
   ansible.builtin.get_url:
-    url: "{{ docker_compose_url }}"
+    url: "{{ docker_compose_v2_url }}"
     dest: "{{ docker_cli_plugins_dir }}/docker-compose"
     owner: root
     group: root
     mode: 0755
-    checksum: "sha256:{{ lookup('url', docker_compose_digest_url) | regex_search('[0-9a-f]{64}') }}"
+    checksum: "sha256:{{ lookup('url', docker_compose_v2_digest_url) | regex_search('[0-9a-f]{64}') }}"
 
-- name: Test the Docker Compose installation
+- name: Test the installation
   ansible.builtin.command: docker compose version
   changed_when: false

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,10 +1,12 @@
 ---
 - name: Install Docker Engine
+  become: true
   block:
     - include_tasks: docker-engine-install.yml
   tags: docker
 
 - name: Make Docker aware of the http proxy
+  become: true
   block:
     - include_tasks: docker-proxy-config.yml
   tags: docker-proxy
@@ -13,6 +15,7 @@
 # it doesn't read the proxy configuration from the config.json file.
 # When this is resolved, this task can switch to docker-compose-install-v2.yml.
 - name: Install Docker Compose
+  become: true
   block:
     - include_tasks: docker-compose-install-v1.yml
   tags: docker-compose

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -9,7 +9,10 @@
     - include_tasks: docker-proxy-config.yml
   tags: docker-proxy
 
+# As of version 2.2.2, Docker Compose V2 has a regression over V1 in that
+# it doesn't read the proxy configuration from the config.json file.
+# When this is resolved, this task can switch to docker-compose-install-v2.yml.
 - name: Install Docker Compose
   block:
-    - include_tasks: docker-compose-install.yml
+    - include_tasks: docker-compose-install-v1.yml
   tags: docker-compose

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -1,5 +1,8 @@
-docker_compose_url: https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64
-docker_compose_digest_url: "{{ docker_compose_url }}.sha256"
+docker_compose_v1_url: "https://github.com/docker/compose/releases/download/{{ docker_compose_v1_release }}/docker-compose-Linux-x86_64"
+docker_compose_v1_digest_url: "{{ docker_compose_v1_url }}.sha256"
+
+docker_compose_v2_url: "https://github.com/docker/compose/releases/download/{{ docker_compose_v2_release }}/docker-compose-linux-x86_64"
+docker_compose_v2_digest_url: "{{ docker_compose_v2_url }}.sha256"
 
 # The cli-plugins directory can be discovered with `dpkg -L docker-ce-cli | grep cli-plugins`
 docker_cli_plugins_dir: /usr/libexec/docker/cli-plugins


### PR DESCRIPTION
Compose V2 has a regression which makes it unable to propagate the proxy environment variables to containers, which results in `docker compose build` failing on our hosts. This role now installs v1 by default, but the v2 play is ready to be used when the regression is fixed. The v1 play undoes the v2 play and vice versa.