### PR TITLE
Add a parameter to control whether an ipa automount should be cached

### DIFF
--- a/ansible/roles/ipaserver_settings/defaults/main.yml
+++ b/ansible/roles/ipaserver_settings/defaults/main.yml
@@ -1,0 +1,5 @@
+# List of automount mappings
+# ipa-automountmaps:
+#   - name: homes
+#     cached: true
+ipa-automountmaps: []

--- a/ansible/roles/ipaserver_settings/tasks/create_automountmaps.yml
+++ b/ansible/roles/ipaserver_settings/tasks/create_automountmaps.yml
@@ -13,7 +13,7 @@
       - ipa
       - automountmap-find
       - default
-      - "auto.{{ mapname }}"
+      - "auto.{{ mountmap['name'] }}"
     tty: true
   become: true
   changed_when: false
@@ -27,7 +27,7 @@
       - ipa
       - automountmap-add
       - default
-      - "auto.{{ mapname }}"
+      - "auto.{{ mountmap['name'] }}"
     tty: true
   become: true
   when: automountmap_search.stdout is search("0 automount maps matched")
@@ -39,8 +39,8 @@
       - ipa
       - automountkey-add
       - default
-      - "--key \"/{{ mapname }}\""
-      - "--info auto.{{ mapname }}"
+      - "--key \"/{{ mountmap['name'] }}\""
+      - "--info auto.{{ mountmap['name'] }}"
       - "auto.master"
     tty: true
   become: true
@@ -54,8 +54,8 @@
       - automountkey-add
       - default
       - "--key \"*\""
-      - "--info \"-fstype=nfs4,rw s1:/dpool/share/{{ mapname }}/&\""
-      - "auto.{{ mapname }}"
+      - "--info \"-{{ 'fsc,' if mountmap['cached'] }}fstype=nfs4,rw s1:/dpool/share/{{ mountmap['name'] }}/&\""
+      - "auto.{{ mountmap['name'] }}"
     tty: true
   become: true
   when: automountmap_search.stdout is search("0 automount maps matched")

--- a/ansible/roles/ipaserver_settings/tasks/main.yml
+++ b/ansible/roles/ipaserver_settings/tasks/main.yml
@@ -37,12 +37,12 @@
 #     - include_tasks: create_automountmaps.yml
 #   run_once: true
 #   loop:
-#     - homes
-#     - projects
-#     - groups
-#     - software
+#     - {{ name: 'homes', cached: true }}
+#     - {{ name: 'projects', cached: true }}
+#     - {{ name: 'groups', cached: true }}
+#     - {{ name: 'software', cached: false }}
 #   loop_control:
-#     loop_var: mapname
+#     loop_var: mountmap
 #   tags:
 #     - ipa-automountmaps
 #     - ipa-settings

--- a/ansible/roles/ipaserver_settings/tasks/main.yml
+++ b/ansible/roles/ipaserver_settings/tasks/main.yml
@@ -36,11 +36,7 @@
 #   block:
 #     - include_tasks: create_automountmaps.yml
 #   run_once: true
-#   loop:
-#     - {{ name: 'homes', cached: true }}
-#     - {{ name: 'projects', cached: true }}
-#     - {{ name: 'groups', cached: true }}
-#     - {{ name: 'software', cached: false }}
+#   loop: "{{ ipa-automountmaps }}"
 #   loop_control:
 #     loop_var: mountmap
 #   tags:


### PR DESCRIPTION
In order to actually make use of cachefilesd, autmount mappings must include the `fsc` option. This PR adds the `fsc` option where appropriate based on the value of a parameter called `cached`.