### PR TITLE
Fix issue #10

### DIFF
--- a/ansible/roles/k8s_setup_longhorn/tasks/main.yml
+++ b/ansible/roles/k8s_setup_longhorn/tasks/main.yml
@@ -8,18 +8,16 @@
 - name: include longhorn install tasks
   block:
     - include_tasks: setup.yml
+  when: inventory_hostname in groups[rke2_primary_server_group_name]
   tags:
     - longhorn
     - longhorn-install
-  run_once: true
-  delegate_to: "{{ primary_rke2_server }}"
 
 - name: include IngressRoutes tasks
   block:
     - include_tasks: ingress.yml
+  when: inventory_hostname in groups[rke2_primary_server_group_name]
   tags:
     - longhorn
     - longhorn-ui-ingress
-  run_once: true
-  delegate_to: "{{ primary_rke2_server }}"
   become: true

--- a/ansible/roles/k8s_setup_monitoring/tasks/main.yml
+++ b/ansible/roles/k8s_setup_monitoring/tasks/main.yml
@@ -4,8 +4,6 @@
   tags:
     - monitoring
     - kube-prometheus
-  run_once: true
-  delegate_to: "{{ primary_rke2_server }}"
 
 - name: include ingress setup tasks
   block:
@@ -13,5 +11,3 @@
   tags:
     - monitoring
     - monitoring-ingress
-  run_once: true
-  delegate_to: "{{ primary_rke2_server }}"

--- a/ansible/roles/k8s_setup_traefik/tasks/main.yml
+++ b/ansible/roles/k8s_setup_traefik/tasks/main.yml
@@ -4,14 +4,10 @@
   tags:
     - traefik
     - metallb
-  run_once: true
-  delegate_to: "{{ primary_rke2_server }}"
 
 - name: include traefik install tasks
   block:
     - include_tasks: install_traefik.yml
   tags:
     - traefik
-  run_once: true
-  delegate_to: "{{ primary_rke2_server }}"
   become: true

--- a/ansible/roles/rke2/tasks/install_rke2.yml
+++ b/ansible/roles/rke2/tasks/install_rke2.yml
@@ -6,6 +6,10 @@
   environment: "{{ proxy_env }}"
   become: true
 
+- name: determine the type of node
+  ansible.builtin.set_fact:
+    rke2_type: "{{ (inventory_hostname in groups[rke2_servers_group_name]) | ternary('server', 'agent') }}"
+
 - name: populate service facts
   ansible.builtin.service_facts:
   become: true
@@ -34,28 +38,6 @@
   when: (rke2_version != ( installed_rke2_version.stdout | default({})))
         or installed_rke2_version is not defined
   become: true
-
-- name: retrieve primary active server
-  ansible.builtin.uri:
-    url: "https://{{ rke2_server_url }}:{{ rke2_apiserver_dest_port }}"
-    method: GET
-    return_content: true
-    use_proxy: false
-    validate_certs: false
-    status_code:
-      - 401
-      - "-1"
-  register: apiserver_curl
-
-- name: set current_server_is_not_first variable
-  ansible.builtin.set_fact:
-    current_server_is_not_first: true
-  when: apiserver_curl['status'] == 401
-
-- name: set current_server_is_not_first variable
-  ansible.builtin.set_fact:
-    current_server_is_not_first: false
-  when: apiserver_curl['status'] != 401
 
 - name: create rke2 config dir
   ansible.builtin.file:
@@ -93,19 +75,10 @@
     enabled: true
   become: true
 
-- name: set the first_run_server variable
-  ansible.builtin.set_fact:
-    first_run_server: "{{ inventory_hostname }}"
-  when:
-    - first_run_server is not defined
-    - rke2_type == "server"
-
 - name: change server reference in kubeconfig from localhost to actual url
   ansible.builtin.replace:
     path: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
     regexp: '(\s+server: https://)127\.0\.0\.1(:6443)'
     replace: '\g<1>{{ rke2_server_url }}\g<2>'
-  when:
-    - first_run_server is defined
-    - first_run_server == inventory_hostname
+  when: rke2_type == 'server'
   become: true

--- a/ansible/roles/rke2/tasks/main.yml
+++ b/ansible/roles/rke2/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: include keepalived tasks
+- name: install keepalived on the rke2 servers
   block:
     - include_tasks: keepalived.yml
   tags:
@@ -16,16 +16,13 @@
     - rke2
     - rke2-disable-swap
 
-# this sets up the primary master by taking the first host that is encountered in the inventory group
-# Potentially this could mean that different hosts are selected on subsequent runs
-# TODO this can be improved by introducing another inventory group with a single server inside
-- name: include rke2 install tasks
+- name: install rke2 on the primary server
   block:
     - include_tasks: install_rke2.yml
+  when: inventory_hostname in groups[rke2_primary_server_group_name]
   tags:
     - rke2
     - install-rke2
-  run_once: true
 
 - name: wait for api server to become available
   ansible.builtin.uri:
@@ -40,10 +37,15 @@
   until: apiserver_query_response['status'] == 401
   retries: 50
   delay: 15
+  when: inventory_hostname not in groups[rke2_primary_server_group_name]
+  tags:
+    - rke2
+    - install-rke2
 
-- name: include rke2 install tasks
+- name: install rke2 on the rest of the cluster
   block:
     - include_tasks: install_rke2.yml
+  when: inventory_hostname not in groups[rke2_primary_server_group_name]
   tags:
     - rke2
     - install-rke2

--- a/ansible/roles/rke2/templates/keepalived.conf.j2
+++ b/ansible/roles/rke2/templates/keepalived.conf.j2
@@ -14,7 +14,7 @@ vrrp_script chk_apiserver {
 vrrp_instance VI_1 {
   interface {{ ansible_default_ipv4.interface }}
   virtual_router_id 11
-{% if primary_rke2_server == inventory_hostname|string() %}
+{% if inventory_hostname in groups[rke2_primary_server_group_name] %}
   state MASTER
 {% else %}
   state BACKUP

--- a/ansible/roles/rke2/templates/server_config.yaml.j2
+++ b/ansible/roles/rke2/templates/server_config.yaml.j2
@@ -1,5 +1,5 @@
 token: {{ rke2_token }}
-{% if current_server_is_not_first %}
+{% if inventory_hostname not in groups[rke2_primary_server_group_name] %}
 server: https://{{ rke2_server_url }}:9345
 {% endif %}
 

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -143,7 +143,7 @@
     - rke2
     - k8s_setup_longhorn
 
-- hosts: rke_masters
+- hosts: primary_rke2_server
   gather_facts: true
   remote_user: ubuntu
   roles:


### PR DESCRIPTION
K8s plays are now consistently executed in the intended order. The RKE2 installation is first performed on the designed primary server, then on the additional servers and finally on all agent nodes.

To make the setup easier to understand at a glance, I've added two sub-groups to the rke server inventory group.