### PR TITLE
Install Nvidia drivers and Cuda separately

### DIFF
--- a/ansible/roles/nvidia/defaults/main.yml
+++ b/ansible/roles/nvidia/defaults/main.yml
@@ -1,5 +1,7 @@
-# To select the appropriate versions, refer to the compatibility matrix:
-# https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html
-cuda_version: "11.6"
+cuda_driver_version: "510"
+
+# To select the appropriate versions of cuda and cudnn, refer to the
+# compatibility matrix: https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html
+cuda_toolkit_version: "11.6"
 cudnn_base_name: "libcudnn8"
 cudnn_version: "8.4.*"

--- a/ansible/roles/nvidia/defaults/main.yml
+++ b/ansible/roles/nvidia/defaults/main.yml
@@ -1,5 +1,5 @@
 # To select the appropriate versions, refer to the compatibility matrix:
 # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html
-cuda_version: "11.5"
+cuda_version: "11.6"
 cudnn_base_name: "libcudnn8"
-cudnn_version: "8.3.*"
+cudnn_version: "8.4.*"

--- a/ansible/roles/nvidia/tasks/nvidia-driver-libs.yml
+++ b/ansible/roles/nvidia/tasks/nvidia-driver-libs.yml
@@ -1,9 +1,18 @@
-- name: Install gpu drivers and the cuda toolkit
+- name: Install gpu drivers
   vars:
     nvidia_driver_ubuntu_install_from_cuda_repo: true
-    nvidia_driver_ubuntu_cuda_package: "{{ cuda_package_name }}"
+    nvidia_driver_branch: "{{ cuda_driver_version }}"
   ansible.builtin.include_role:
     name: nvidia.nvidia_driver
+
+- name: Test the driver installation
+  ansible.builtin.command: /usr/bin/nvidia-smi
+  changed_when: false
+
+- name: Install the cuda toolkit
+  ansible.builtin.apt:
+    name: "{{ cuda_toolkit_package_name }}"
+    state: present
 
 - name: Add the cuda compiler to PATH
   ansible.builtin.copy:
@@ -13,17 +22,13 @@
     group: root
     mode: 0644
 
+- name: Test the cuda installation
+  ansible.builtin.command: /usr/local/cuda/bin/nvcc -V
+  changed_when: false
+
 - name: Install cuDNN
   ansible.builtin.apt:
     name:
       - "{{ cudnn_package_spec }}"
       - "{{ cudnn_dev_package_spec }}"
     state: present
-
-- name: Test the driver installation
-  ansible.builtin.command: /usr/bin/nvidia-smi
-  changed_when: false
-
-- name: Test the cuda installation
-  ansible.builtin.command: /usr/local/cuda/bin/nvcc -V
-  changed_when: false

--- a/ansible/roles/nvidia/vars/main.yml
+++ b/ansible/roles/nvidia/vars/main.yml
@@ -1,4 +1,4 @@
-cuda_package_name: "cuda-{{ cuda_version | replace('.', '-') }}"
-cudnn_package_spec: "{{ cudnn_base_name }}={{ cudnn_version }}-1+cuda{{ cuda_version }}"
-cudnn_dev_package_spec: "{{ cudnn_base_name }}-dev={{ cudnn_version }}-1+cuda{{ cuda_version }}"
-cuda_nvidia_image: "nvidia/cuda:{{ cuda_version }}.0-base"
+cuda_toolkit_package_name: "cuda-{{ cuda_toolkit_version | replace('.', '-') }}"
+cudnn_package_spec: "{{ cudnn_base_name }}={{ cudnn_version }}-1+cuda{{ cuda_toolkit_version }}"
+cudnn_dev_package_spec: "{{ cudnn_base_name }}-dev={{ cudnn_version }}-1+cuda{{ cuda_toolkit_version }}"
+cuda_nvidia_image: "nvidia/cuda:{{ cuda_toolkit_version }}.0-base"


### PR DESCRIPTION
Instead of installing the cuda metapackage which handles both drivers and libraries, the cuda toolkit metapackage and the drivers package are now installed separately. This avoids some package dependency issues when installing new versions.