### PR TITLE
Allow defining a pre-shared rke2 token

### DIFF
--- a/ansible/roles/rke2/tasks/install_rke2.yml
+++ b/ansible/roles/rke2/tasks/install_rke2.yml
@@ -66,6 +66,27 @@
   become: true
   notify: "restart rke2-{{ rke2_type }}"
 
+- name: create a systemd service config directory
+  ansible.builtin.file:
+    path: "/etc/systemd/system/rke2-{{ rke2_type }}.service.d"
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
+  when: inventory_hostname in groups[rke2_primary_server_group_name]
+  become: true
+
+- name: write the secret token in a systemd service configuration file
+  ansible.builtin.template:
+    src: rke2-token.conf.j2
+    dest: "/etc/systemd/system/rke2-{{ rke2_type }}.service.d/rke2-token.conf"
+    owner: root
+    group: root
+    mode: 0600
+  when: inventory_hostname in groups[rke2_primary_server_group_name]
+  become: true
+  notify: "restart rke2-{{ rke2_type }}"
+
 # Ansible might report this task as failed when in reality it just needs a
 # little longer to start up.
 - name: start and enable the systemd service

--- a/ansible/roles/rke2/templates/rke2-token.conf.j2
+++ b/ansible/roles/rke2/templates/rke2-token.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+Environment="RKE2_TOKEN={{ rke2_token }}"

--- a/ansible/roles/rke2/templates/server_config.yaml.j2
+++ b/ansible/roles/rke2/templates/server_config.yaml.j2
@@ -1,5 +1,5 @@
-token: {{ rke2_token }}
 {% if inventory_hostname not in groups[rke2_primary_server_group_name] %}
+token: {{ rke2_token }}
 server: https://{{ rke2_server_url }}:9345
 {% endif %}
 


### PR DESCRIPTION
The host group variable `rke2_token` can now be used to bootstrap an rke2 cluster.