### PR TITLE
Install direnv on gpu nodes.

### DIFF
--- a/ansible/roles/g_node_devtools/tasks/main.yml
+++ b/ansible/roles/g_node_devtools/tasks/main.yml
@@ -7,5 +7,6 @@
       - zsh
       - openslide-tools
       - rename
+      - direnv
     state: present
   tags: g-node-devtools


### PR DESCRIPTION
A user requested https://direnv.net. I think it's harmless enough to add it to the general devtools role for gpu nodes.