### PR TITLE
Feature/timesync

### DIFF
--- a/ansible/roles/ipaserver/templates/ipa-server-install-options.j2
+++ b/ansible/roles/ipaserver/templates/ipa-server-install-options.j2
@@ -1,3 +1,4 @@
 --realm={{ ipaserver_realm }}
 --ds-password={{ ipadm_password }}
 --admin-password={{ ipaadmin_password }}
+--no-ntp

--- a/ansible/roles/ntpclient/defaults/main.yml
+++ b/ansible/roles/ntpclient/defaults/main.yml
@@ -1,0 +1,1 @@
+ntp_server_ip: ""

--- a/ansible/roles/ntpclient/tasks/main.yml
+++ b/ansible/roles/ntpclient/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Verify that the NTP client is configured correctly
+  become: true
+  block:
+    - include_tasks: timesyncd.yml
+  tags: ntpclient

--- a/ansible/roles/ntpclient/tasks/timesyncd.yml
+++ b/ansible/roles/ntpclient/tasks/timesyncd.yml
@@ -1,0 +1,27 @@
+---
+- name: Make sure that ntpd and chrony are uninstalled
+  ansible.builtin.apt:
+    name:
+      - ntp
+      - chrony
+    state: absent
+
+- name: Make sure that timesyncd is installed
+  ansible.builtin.apt:
+    name:
+      - systemd-timesyncd
+    state: present
+
+- name: Enable and start the timesyncd service
+  ansible.builtin.systemd:
+    name: systemd-timesyncd
+    state: started
+    masked: false
+    enabled: true
+
+- name: Verify that timesyncd is configured correctly
+  ansible.builtin.command: timedatectl show-timesync
+  register: cmd_timedatectl
+  changed_when: false
+  failed_when: ('ServerAddress=' ~ ntp_server_ip) not in cmd_timedatectl['stdout_lines']
+  become: false

--- a/ansible/roles/ntpclient/tasks/timesyncd.yml
+++ b/ansible/roles/ntpclient/tasks/timesyncd.yml
@@ -12,6 +12,15 @@
       - systemd-timesyncd
     state: present
 
+# Since the packages ntp, chrony and systemd-timesyncd are mutually exclusive,
+# if ntp or chrony are installed manually or as dependencies, they remove
+# systemd-timesyncd and risk breaking the configuration. To prevent this,
+# mark systemd-timesyncd as held.
+- name: Prevent apt from automatically removing systemd-timesyncd
+  ansible.builtin.command: apt-mark hold systemd-timesyncd
+  register: cmd_apt_mark
+  changed_when: cmd_apt_mark['stdout'] == 'systemd-timesyncd set on hold.'
+
 - name: Enable and start the timesyncd service
   ansible.builtin.systemd:
     name: systemd-timesyncd

--- a/ansible/roles/timezone/defaults/main.yml
+++ b/ansible/roles/timezone/defaults/main.yml
@@ -1,0 +1,1 @@
+timezone: Etc/UTC

--- a/ansible/roles/timezone/tasks/main.yml
+++ b/ansible/roles/timezone/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Set the timezone
+  become: true
+  community.general.timezone:
+    name: "{{ timezone }}"
+  tags: timezone

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,4 +1,13 @@
 ---
+- hosts: all
+  remote_user: ubuntu
+  roles:
+    - timezone
+
+- hosts: all:!origin
+  remote_user: ubuntu
+  roles:
+    - ntpclient
 
 - hosts: dns_servers
   become: true
@@ -81,12 +90,6 @@
   remote_user: ubuntu
   gather_facts: true
   environment: "{{ proxy_env | default({}) }}"
-  pre_tasks:
-    - name: Install prerequisites
-      ansible.builtin.apt:
-        name:
-          - chrony
-      tags: freeIPA-client
   roles:
     - role: freeipa.ansible_freeipa.ipaclient
       state: present


### PR DESCRIPTION
The fact that ntp, chrony and systemd-timesyncd are mutually exclusive packages can create nasty surprises. The new role "ntpclient" ensures that the time sync configuration from MAAS is not sabotaged by other things bringing chrony or ntp in as dependencies.

Adding a timezone role as well for the sake of keeping all nodes consistent.