### PR TITLE
feat: eclipse che roles

### DIFF
--- a/ansible/roles/eclipse_che/main.yml
+++ b/ansible/roles/eclipse_che/main.yml
@@ -1,0 +1,15 @@
+- name: Download chectl installer
+  ansible.builtin.get_url:
+    url: https://www.eclipse.org/che/chectl
+    dest: /tmp/chectl-install.sh
+
+# Install chectl to /usr/local/bin/chectl
+- name: Install chectl
+  ansible.builtin.command: bash /tmp/chectl-install.sh
+
+# follwing instructions for kind: https://www.eclipse.org/che/docs/che-7/installation-guide/installing-che-on-kind/
+# requirements:
+# - ingress
+# - persistent volume management
+- name: Deploy eclipse che
+  ansible.builtin.command: chectl server:deploy --installer operator --platform k8s --domain <TODO insert correct domain here>


### PR DESCRIPTION
This is my first try, basically just replicating the che docs. I hope I am getting this about right. I am unsure about how to integrate in site.yml since I guess not every k8s cluster we deploy should also have ché. Hence, there should perhaps be dedicated group of hosts `che_cluster` or so?

Also, this is completely untested for now.

Any feedback or help welcome.