### PR TITLE
Prefer cachefilesd defaults

### DIFF
--- a/ansible/roles/nfs_client/defaults/main.yml
+++ b/ansible/roles/nfs_client/defaults/main.yml
@@ -1,7 +1,14 @@
 ipa_automounts_enabled: false
 
 cachefilesd_enabled: false
-cachefilesd_dir: /var/cache/fscache
+
+# List of options to override in /etc/cachefilesd.conf.
+# cachefilesd_options:
+#   - name: dir
+#     value: /var/cache/fscache
+#   - name: brun
+#     value: "10%"
+cachefilesd_options: []
 
 autofs_root: /mnt
 

--- a/ansible/roles/nfs_client/tasks/cachefilesd.yml
+++ b/ansible/roles/nfs_client/tasks/cachefilesd.yml
@@ -9,13 +9,17 @@
     enabled: true
     state: started
 
-- name: Copy the configuration file
-  ansible.builtin.template:
-    src: cachefilesd.conf.j2
-    dest: /etc/cachefilesd.conf
+- name: Tweak the cachefilesd settings
+  ansible.builtin.lineinfile:
+    path: /etc/cachefilesd.conf
+    regexp: "^{{ nfs_client_item['name'] }}\\s"
+    line: "{{ nfs_client_item['name'] }} {{ nfs_client_item['value'] }}"
     owner: root
     group: root
     mode: 0644
+  loop: "{{ cachefilesd_options }}"
+  loop_control:
+    loop_var: nfs_client_item
   when: cachefilesd_enabled
   notify: restart cachefilesd
 

--- a/ansible/roles/nfs_client/templates/cachefilesd.conf.j2
+++ b/ansible/roles/nfs_client/templates/cachefilesd.conf.j2
@@ -1,6 +1,0 @@
-dir {{ cachefilesd_dir }}
-secctx cachefiles_kernel_t
-brun 10%
-bcull 7%
-bstop 3%
-#secctx system_u:system_r:cachefiles_kernel_t:s0


### PR DESCRIPTION
Instead of replacing the entire configuration file, only lines related to specific options are modified. Incidentally, our configuration file had a SELinux-specific directive, which breaks cachefilesd in Ubuntu 22.04.