### PR TITLE
Stop installing cudnn

### DIFF
--- a/ansible/roles/nvidia/defaults/main.yml
+++ b/ansible/roles/nvidia/defaults/main.yml
@@ -1,7 +1,2 @@
 cuda_driver_version: "515"
-
-# To select the appropriate versions of cuda and cudnn, refer to the
-# compatibility matrix: https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html
 cuda_toolkit_version: "11.7"
-cudnn_base_name: "libcudnn8"
-cudnn_version: "8.4.*"

--- a/ansible/roles/nvidia/tasks/nvidia-driver-libs.yml
+++ b/ansible/roles/nvidia/tasks/nvidia-driver-libs.yml
@@ -25,10 +25,3 @@
 - name: Test the cuda installation
   ansible.builtin.command: /usr/local/cuda/bin/nvcc -V
   changed_when: false
-
-- name: Install cuDNN
-  ansible.builtin.apt:
-    name:
-      - "{{ cudnn_package_spec }}"
-      - "{{ cudnn_dev_package_spec }}"
-    state: present

--- a/ansible/roles/nvidia/vars/main.yml
+++ b/ansible/roles/nvidia/vars/main.yml
@@ -1,4 +1,2 @@
 cuda_toolkit_package_name: "cuda-{{ cuda_toolkit_version | replace('.', '-') }}"
-cudnn_package_spec: "{{ cudnn_base_name }}={{ cudnn_version }}-1+cuda{{ cuda_toolkit_version }}"
-cudnn_dev_package_spec: "{{ cudnn_base_name }}-dev={{ cudnn_version }}-1+cuda{{ cuda_toolkit_version }}"
 cuda_nvidia_image: "nvidia/cuda:{{ cuda_toolkit_version }}.0-base-{{ ansible_distribution | lower }}{{ ansible_distribution_version }}"


### PR DESCRIPTION
People normally use cudnn via pytorch or conda, which is a better approach.