### PR TITLE
Enable "enumerate" in sssd.conf on slurm nodes.

### DIFF
--- a/ansible/roles/slurm_node/handlers/main.yml
+++ b/ansible/roles/slurm_node/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart sssd
+  become: true
+  ansible.builtin.systemd:
+    name: sssd
+    state: restarted

--- a/ansible/roles/slurm_node/tasks/main.yml
+++ b/ansible/roles/slurm_node/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Enable the enumerate option in sssd.conf
+  block:
+    - include_tasks: sssd_enumerate.yml
+  tags: slurm-node

--- a/ansible/roles/slurm_node/tasks/main.yml
+++ b/ansible/roles/slurm_node/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Enable the enumerate option in sssd.conf
+  become: true
   block:
     - include_tasks: sssd_enumerate.yml
   tags: slurm-node

--- a/ansible/roles/slurm_node/tasks/sssd_enumerate.yml
+++ b/ansible/roles/slurm_node/tasks/sssd_enumerate.yml
@@ -1,0 +1,7 @@
+- name: Enable the enumerate option in sssd.conf
+  ansible.builtin.template:
+    src: 01_slurm.conf.j2
+    dest: /etc/sssd/conf.d/01_slurm.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/roles/slurm_node/tasks/sssd_enumerate.yml
+++ b/ansible/roles/slurm_node/tasks/sssd_enumerate.yml
@@ -5,3 +5,4 @@
     owner: root
     group: root
     mode: 0644
+  notify: restart sssd

--- a/ansible/roles/slurm_node/templates/01_slurm.conf.j2
+++ b/ansible/roles/slurm_node/templates/01_slurm.conf.j2
@@ -1,2 +1,2 @@
-[domain/ikim.uk-essen.de]
+[domain/{{ ansible_facts['domain'] }}]
 enumerate = true

--- a/ansible/roles/slurm_node/templates/01_slurm.conf.j2
+++ b/ansible/roles/slurm_node/templates/01_slurm.conf.j2
@@ -1,0 +1,2 @@
+[domain/ikim.uk-essen.de]
+enumerate = true

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -126,6 +126,12 @@
     - user_skel
 
 
+- hosts: slurm_nodes
+  environment: "{{ proxy_env | default({}) }}"
+  roles:
+    - slurm_node
+
+
 - hosts: rke_k8s_cluster
   gather_facts: true
   remote_user: ubuntu


### PR DESCRIPTION
Requested by @ryade76. I've created a new role and a new host group that we can use to add other slurm-related tasks in the future.