### PR TITLE
Disable multipathd on Longhorn devices.

### DIFF
--- a/ansible/roles/k8s_setup_longhorn/files/01_longhorn.conf
+++ b/ansible/roles/k8s_setup_longhorn/files/01_longhorn.conf
@@ -1,0 +1,3 @@
+blacklist {
+    devnode "^sd[a-z0-9]+"
+}

--- a/ansible/roles/k8s_setup_longhorn/handlers/main.yml
+++ b/ansible/roles/k8s_setup_longhorn/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: reload multipathd
+  become: true
+  ansible.builtin.systemd:
+    name: multipathd
+    state: reloaded

--- a/ansible/roles/k8s_setup_longhorn/tasks/main.yml
+++ b/ansible/roles/k8s_setup_longhorn/tasks/main.yml
@@ -1,3 +1,11 @@
+---
+# Source: https://longhorn.io/kb/troubleshooting-volume-with-multipath/
+- name: Disallow multipath on Longhorn devices
+  block:
+    - include_tasks: multipath-disallow.yml
+  tags: longhorn-multipath-disallow
+  become: true
+
 - name: include longhorn preparation tasks
   block:
     - include_tasks: prep.yml

--- a/ansible/roles/k8s_setup_longhorn/tasks/multipath-disallow.yml
+++ b/ansible/roles/k8s_setup_longhorn/tasks/multipath-disallow.yml
@@ -1,0 +1,28 @@
+- name: Read the multipath configuration
+  ansible.builtin.command: multipath -t
+  changed_when: false
+  register: cmd_multipath
+
+- name: Parse the configuration directory value
+  ansible.builtin.set_fact:
+    multipath_config_dir: "{{ cmd_multipath['stdout'] | regex_findall('config_dir \"(.+?)\"') | last }}"
+  when: cmd_multipath is not skipped
+
+- name: Make sure the configuration directory exists
+  ansible.builtin.file:
+    path: "{{ multipath_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: multipath_config_dir is defined
+
+- name: Add the longhorn configuration
+  ansible.builtin.copy:
+    src: 01_longhorn.conf
+    dest: "{{ multipath_config_dir }}/01_longhorn.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when: multipath_config_dir is defined
+  notify: reload multipathd


### PR DESCRIPTION
Fix an issue with services being unable to mount volumes on Longhorn. Source: https://longhorn.io/kb/troubleshooting-volume-with-multipath/.