### PR TITLE
fix linter.yml

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,7 +6,7 @@ exclude_paths:
   - ansible/roles/k8s_setup_monitoring/files/manifests/
 # parseable: true
 # quiet: true
-# verbosity: 1
+verbosity: -2
 
 # Mock modules or roles in order to pass ansible-playbook --syntax-check
 # mock_modules:
@@ -34,7 +34,8 @@ use_default_rules: true
 #   - ./rule/directory/
 
 # This makes linter to fully ignore rules/tags listed below
-# skip_list:
+skip_list:
+  - name[casing]  # Rule for checking task and play names.
 
 # Any rule that has the 'opt-in' tag will not be loaded unless its 'id' is
 # mentioned in the enable_list:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -21,3 +21,5 @@ jobs:
 
       - name: Lint ansible project
         uses: ansible-community/ansible-lint-action@v6
+        with:
+          path: "ansible/roles"

--- a/ansible/roles/k8s_setup_monitoring/tasks/configure_prometheus_targets.yml
+++ b/ansible/roles/k8s_setup_monitoring/tasks/configure_prometheus_targets.yml
@@ -1,4 +1,4 @@
-
+---
 - name: create prometheus additional config resource
   kubernetes.core.k8s:
     state: present

--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -1,4 +1,4 @@
-
+---
 - name: ensure slurmctld namespace
   kubernetes.core.k8s:
     state: present

--- a/ansible/roles/mambaforge/tasks/main.yml
+++ b/ansible/roles/mambaforge/tasks/main.yml
@@ -11,6 +11,7 @@
   ansible.builtin.get_url:
     url: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
     dest: /tmp/mambaforge.sh
+    mode: 0755
   when: cmd_conda_version.rc != 0
 
 - name: Install mambaforge into /opt/mambaforge

--- a/ansible/roles/rke2/tasks/install_rke2.yml
+++ b/ansible/roles/rke2/tasks/install_rke2.yml
@@ -35,7 +35,7 @@
     HTTP_PROXY: "{{ http_proxy }}"
     HTTPS_PROXY: "{{ http_proxy }}"
     NO_PROXY: "{{ no_proxy }}"
-  when: (rke2_version != ( installed_rke2_version.stdout | default({})))
+  when: (rke2_version != (installed_rke2_version.stdout | default({})))
         or installed_rke2_version is not defined
   become: true
 

--- a/ansible/roles/subidmap/tasks/calculate_range.yml
+++ b/ansible/roles/subidmap/tasks/calculate_range.yml
@@ -33,7 +33,7 @@
 
 - name: Calculate the last possible IPA ID
   ansible.builtin.set_fact:
-    last_ipa_id: "{{ first_ipa_id|int + ipa_range_size|int - 1 }}"
+    last_ipa_id: "{{ first_ipa_id | int + ipa_range_size | int - 1 }}"
   when:
     - first_ipa_id is defined
     - ipa_range_size is defined
@@ -64,7 +64,7 @@
 # of users defined by mappable_users_cap.
 - name: Find a suitable value for the last subordinate ID
   ansible.builtin.set_fact:
-    subid_stop: "{{ subid_start|int + mappable_users_cap*subid_step }}"
+    subid_stop: "{{ subid_start | int + mappable_users_cap * subid_step }}"
   when: subid_start is defined
 
 - name: Make sure that the last subordinate ID does not overflow

--- a/ansible/roles/telegraf_systemd/handlers/main.yml
+++ b/ansible/roles/telegraf_systemd/handlers/main.yml
@@ -1,4 +1,4 @@
-
+---
 - name: restart telegraf
   ansible.builtin.systemd:
     name: telegraf

--- a/ansible/roles/telegraf_systemd/tasks/configure_telegraf.yml
+++ b/ansible/roles/telegraf_systemd/tasks/configure_telegraf.yml
@@ -1,4 +1,4 @@
-
+---
 - name: write the telegraf config file
   ansible.builtin.template:
     src: telegraf.conf.j2

--- a/ansible/roles/telegraf_systemd/tasks/install_telegraf.yml
+++ b/ansible/roles/telegraf_systemd/tasks/install_telegraf.yml
@@ -1,4 +1,4 @@
-
+---
 - name: get influxdata apt repo key
   ansible.builtin.get_url:
     url: https://repos.influxdata.com/influxdb.key

--- a/ansible/roles/telegraf_systemd/tasks/main.yml
+++ b/ansible/roles/telegraf_systemd/tasks/main.yml
@@ -1,4 +1,4 @@
-
+---
 - name: include telegraf setup tasks
   block:
     - include_tasks: install_telegraf.yml


### PR DESCRIPTION
The latest release of ansible builder image 'quay.io/ansible/creator-ee:v0.7.1' uses ansible-lint-action:v6.5.2 in which path of the roles has to be mentioned under ansible-lint to examine all role based on the rules defined in the linter configuration file.
