### PR TITLE
Change the path of ansible's remote temp dir

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,5 +3,6 @@
 host_key_checking = False
 interpreter_python = auto
 roles_path = ~/.ansible/roles:./roles:/usr/share/ansible/roles:/etc/ansible/roles
+remote_tmp = /tmp/.ansible
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
By default, ansible creates a temp directory in the user's home on the remote host, but this doesn't work well with homes on NFS. Moving the remote temp to /tmp fixes the issue.