### PR TITLE
changed config file name in the role ssh_config

### DIFF
--- a/ansible/roles/ssh_config/tasks/main.yml
+++ b/ansible/roles/ssh_config/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Add system-wide SSH config to access github.com and gitlab.com.
   ansible.builtin.template:
     src: "{{ ssh_config_item }}.j2"
-    dest: "/etc/ssh/ssh_config.d/{{ ssh_config_item }}"
+    dest: "/etc/ssh/ssh_config.d/00-{{ ssh_config_item }}"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
The first entry in the ssh_config.d always takes precedence. During the ipa installation step, a specific system-wide ssh_config file gets added into the ssh_config.d with a certain nomenclature pattern, later which takes precedence among other system-wide ssh config files such as github.com.conf, gitlab.com.conf. And also inside the ipa ssh_config file, its stated that Host * matches true it exec the ProxyCommand  /usr/bin/sss_ssh_knownhostsproxy -p %p %h. In this case,  even though the host matches in the github/gitlab config files, it can't replace the ssh configuration made via ipa ssh_config as it's configured for all hosts. So therefore to tackle this, edited a file name of GitHub & GitLab config files, so that they take precedence with ipa ssh configuration.