### PR TITLE
Reorganise the default slurm group hostgroup hierarchy

### DIFF
--- a/ansible/roles/slurm/defaults/main.yml
+++ b/ansible/roles/slurm/defaults/main.yml
@@ -1,7 +1,8 @@
 # Inventory group names
+slurm_packager_group_name: slurm_packager
+slurm_node_group_name: slurm_node
 slurm_controller_group_name: slurm_controller
-slurm_user_group_name: slurm_user
-slurm_pkgrepo_group_name: slurm_pkgrepo
+slurm_user_facing_group_name: slurm_user_facing
 slurm_compute_group_name: slurm_compute
 
 # The version to install

--- a/ansible/roles/slurm/tasks/main.yml
+++ b/ansible/roles/slurm/tasks/main.yml
@@ -3,7 +3,7 @@
   become: true
   block:
     - include_tasks: sssd_enumerate.yml
-  when: (inventory_hostname in groups[slurm_controller_group_name]) or (inventory_hostname in groups[slurm_user_group_name])
+  when: (inventory_hostname in groups[slurm_controller_group_name]) or (inventory_hostname in groups[slurm_user_facing_group_name])
   tags:
     - slurm
     - slurm-sssd
@@ -16,7 +16,7 @@
         - jammy
       loop_control:
         loop_var: slurm_item
-  when: inventory_hostname in groups[slurm_pkgrepo_group_name]
+  when: inventory_hostname in groups[slurm_packager_group_name]
   tags:
     - slurm
     - slurm-build


### PR DESCRIPTION
- `slurm_pkgrepo` -> `slurm packager`: this node is responsible for building the slurm package for Ubuntu, but isn't necessarily part of the slurm installation.
- `slurm_user` -> `slurm_user_facing`: this is the node where users can log in and issue jobs.
- `slurm_node`: a new group which sets the actual slurm nodes apart from the packager node. It can be used for distributing the slurm config file.