### PR TITLE
Assign to remote_tmp a value based on username

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,6 +3,6 @@
 host_key_checking = False
 interpreter_python = auto
 roles_path = ~/.ansible/roles:./roles:/usr/share/ansible/roles:/etc/ansible/roles
-remote_tmp = /tmp/.ansible/$USER
+remote_tmp = /tmp/.ansible_$USER
 [ssh_connection]
 pipelining = True

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,6 +3,6 @@
 host_key_checking = False
 interpreter_python = auto
 roles_path = ~/.ansible/roles:./roles:/usr/share/ansible/roles:/etc/ansible/roles
-remote_tmp = /tmp/.ansible
+remote_tmp = /tmp/.ansible/$USER
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
This should resolve permission issues caused by 982827b when different users run plays on the same target host.