### PR TITLE
Do systemctl restart instead of reload with slurmd

### DIFF
--- a/ansible/roles/slurm_install/handlers/main.yml
+++ b/ansible/roles/slurm_install/handlers/main.yml
@@ -1,15 +1,15 @@
 ---
-- name: reload slurmctld
+- name: restart slurmctld
   become: true
   community.general.supervisorctl:
     name: slurmctld
     state: restarted
 
-- name: reload slurmd
+- name: restart slurmd
   become: true
   ansible.builtin.systemd:
     name: slurmd
-    state: reloaded
+    state: restarted
 
 - name: restart munge systemd
   become: true

--- a/ansible/roles/slurm_install/tasks/slurm_configure.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: "reload {{ slurm_daemon_name }}"
+  notify: "restart {{ slurm_daemon_name }}"
 
 - name: Add the GPU configuration file
   ansible.builtin.template:
@@ -18,7 +18,7 @@
   when:
     - ansible_local['gpu']['count'] is defined
     - ansible_local['gpu']['count'] > 0
-  notify: "reload {{ slurm_daemon_name }}"
+  notify: "restart {{ slurm_daemon_name }}"
 
 - name: Add the main configuration file
   ansible.builtin.template:
@@ -27,4 +27,4 @@
     owner: root
     group: root
     mode: 0644
-  notify: "reload {{ slurm_daemon_name }}"
+  notify: "restart {{ slurm_daemon_name }}"


### PR DESCRIPTION
With certain configuration changes, reloading `slurmd` is not enough. Restarting is safer.