### PR TITLE
Provide a value to RealMemory in slurm.conf

### DIFF
--- a/ansible/roles/slurm_install/defaults/main.yml
+++ b/ansible/roles/slurm_install/defaults/main.yml
@@ -27,9 +27,15 @@ slurm_munge_secret: "{{ vault_slurm_munge_secret }}"
 # Cluster name for the configuration file
 slurm_cluster_name: slurmcluster
 
-# The amount of memory on each node that should *not* be available to slurm jobs.
-# The usable memory is obtained by subtracting slurm_reserved_mem_mb from the
-# physical memory.
+# The amount of memory on each node that is *not* intended to be usable by
+# slurm jobs. The usable memory is obtained by subtracting slurm_reserved_mem_mb
+# from the physical memory.
+# Note that this policy is enforced only if memory is declared as a consumable
+# resource in slurm.conf, in which case slurm prevents allocating more than the
+# usable memory. If memory is not a consumable resource, the usable memory is
+# simply the maximum that a job can request on a given node, but slurm will not
+# enforce any limits.
+# See https://slurm.schedmd.com/cons_res.html for details.
 slurm_reserved_mem_mb: 4096
 
 # The compute node partitions as a list of hashes.

--- a/ansible/roles/slurm_install/defaults/main.yml
+++ b/ansible/roles/slurm_install/defaults/main.yml
@@ -27,6 +27,11 @@ slurm_munge_secret: "{{ vault_slurm_munge_secret }}"
 # Cluster name for the configuration file
 slurm_cluster_name: slurmcluster
 
+# The amount of memory on each node that should *not* be available to slurm jobs.
+# The usable memory is obtained by subtracting slurm_reserved_mem_mb from the
+# physical memory.
+slurm_reserved_mem_mb: 4096
+
 # The compute node partitions as a list of hashes.
 # Each hash has the following keys:
 #   name: the partition name as a string

--- a/ansible/roles/slurm_install/templates/slurm.conf.j2
+++ b/ansible/roles/slurm_install/templates/slurm.conf.j2
@@ -58,7 +58,8 @@ SlurmdLogFile=/var/log/slurmd.log
 GresTypes=gpu
 {% for host in groups[slurm_worker_group_name] %}
 {% set gpu_count = hostvars[host]['ansible_local']['gpu']['count'] | default(0) %}
-NodeName={{ hostvars[host]['ansible_hostname'] }} {% if gpu_count > 0 -%} Gres=gpu:{{ gpu_count }} {% endif -%} CPUs={{ hostvars[host]['ansible_processor_nproc'] }} Boards=1 SocketsPerBoard={{ hostvars[host]['ansible_processor_count'] }} CoresPerSocket={{ hostvars[host]['ansible_processor_cores'] }} ThreadsPerCore={{ hostvars[host]['ansible_processor_threads_per_core'] }} State=UNKNOWN
+{% set usable_memory = hostvars[host]['ansible_memtotal_mb'] - slurm_reserved_mem_mb %}
+NodeName={{ hostvars[host]['ansible_hostname'] }} {% if gpu_count > 0 -%} Gres=gpu:{{ gpu_count }} {% endif -%} CPUs={{ hostvars[host]['ansible_processor_nproc'] }} RealMemory={{ usable_memory }} Boards=1 SocketsPerBoard={{ hostvars[host]['ansible_processor_count'] }} CoresPerSocket={{ hostvars[host]['ansible_processor_cores'] }} ThreadsPerCore={{ hostvars[host]['ansible_processor_threads_per_core'] }} State=UNKNOWN
 {% endfor %}
 
 # PARTITIONS


### PR DESCRIPTION
This makes it possible to select nodes based on the available memory by using the `--mem` parameter when submitting a job. Since memory is not a consumable resource in the current config file template, memory usage is not tracked. Slurm only checks that the value passed to `--mem` is lower than the value of RealMemory from the config file.