### PR TITLE
Use the extended format for SlurmctldHost

### DIFF
--- a/ansible/roles/slurm_install/templates/slurm.conf.j2
+++ b/ansible/roles/slurm_install/templates/slurm.conf.j2
@@ -4,11 +4,7 @@
 #
 ClusterName={{ slurm_cluster_name }}
 {% for host in groups[slurm_controller_group_name] %}
-{% if host == inventory_hostname %}
-SlurmctldHost={{ ansible_facts['hostname'] }}
-{% else %}
-SlurmctldHost={{ host }}
-{% endif %}
+SlurmctldHost={{ hostvars[host]['ansible_hostname'] }}({{ host }})
 {% endfor %}
 #
 #MailProg=/bin/mail


### PR DESCRIPTION
Fixes the slurm.conf mismatch between controller and workers by specifying both the inventory name and the actual hostname of the controller.