### PR TITLE
Increase the wait time for killing jobs in slurm

### DIFF
--- a/ansible/roles/slurm_install/templates/slurm.conf.j2
+++ b/ansible/roles/slurm_install/templates/slurm.conf.j2
@@ -25,10 +25,11 @@ TaskPlugin=task/affinity
 #
 #
 # TIMERS
-#KillWait=30
+KillWait=60
 #MinJobAge=300
 #SlurmctldTimeout=120
 #SlurmdTimeout=300
+UnkillableStepTimeout=120
 #
 #
 # SCHEDULING


### PR DESCRIPTION
When executing scancel, jobs are now given one minute to respond to a SIGTERM and two minutes to respond to a SIGKILL before being declared unkillable. The defaults are respectively 30 seconds and one minute. When slurm declares a job unkillable, it brings the node down until manual maintenance is performed.