### PR TITLE
Fix/slurmctld k8s service

### DIFF
--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -7,25 +7,6 @@
     kind: Namespace
     name: "{{ slurm_namespace }}"
 
-- name: Create slurmctld service
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: v1
-      kind: Service
-      metadata:
-        namespace: "{{ slurm_namespace }}"
-        name: slurmctld-service
-      spec:
-        selector:
-          app: slurmctld
-        ports:
-          - name: slurmctld
-            protocol: TCP
-            port: "{{ slurmctld_external_port }}"
-            targetPort: "{{ slurmctld_internal_port }}"
-    state: present
-
 - name: Create slurmctld ssh service
   kubernetes.core.k8s:
     kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
@@ -45,26 +26,7 @@
             targetPort: "{{ slurmctld_internal_ssh_port }}"
     state: present
 
-- name: Create slurmctld ingress route
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: traefik.containo.us/v1alpha1
-      kind: IngressRouteTCP
-      metadata:
-        name: slurmctld-route
-        namespace: "{{ slurm_namespace }}"
-      spec:
-        entryPoints:
-          - slurmctld
-        routes:
-          - match: "HostSNI(`*`)"
-            services:
-              - name: slurmctld-service
-                namespace: "{{ slurm_namespace }}"
-                port: "{{ slurmctld_external_port }}"
-    state: present
-
+# Put the ssh service behind Traefik's TCP proxy.
 - name: Create slurmctld ssh ingress route
   kubernetes.core.k8s:
     kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
@@ -83,6 +45,31 @@
               - name: slurmctldssh-service
                 namespace: "{{ slurm_namespace }}"
                 port: "{{ slurmctld_external_ssh_port }}"
+    state: present
+
+- name: Create slurmctld service
+  kubernetes.core.k8s:
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        namespace: "{{ slurm_namespace }}"
+        name: slurmctld-service
+        annotations:
+          metallb.universe.tf/loadBalancerIPs: "{{ slurmctld_lb_ip | default(omit) }}"
+      spec:
+        selector:
+          app: slurmctld
+        ports:
+          - name: slurmctld
+            protocol: TCP
+            port: "{{ slurmctld_external_port }}"
+            targetPort: "{{ slurmctld_internal_port }}"
+        # Since slurmctld needs to see the source IP from slurm clients, deploy
+        # it as a LoadBalancer service with externalTrafficPolicy set to Local.
+        externalTrafficPolicy: Local
+        type: LoadBalancer
     state: present
 
 - name: Create slurmctld deployment

--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -16,6 +16,8 @@
       metadata:
         namespace: "{{ slurm_namespace }}"
         name: slurmctldssh-service
+        annotations:
+          metallb.universe.tf/loadBalancerIPs: "{{ slurmctld_lb_ip | default(omit) }}"
       spec:
         selector:
           app: slurmctld
@@ -24,27 +26,7 @@
             protocol: TCP
             port: "{{ slurmctld_external_ssh_port }}"
             targetPort: "{{ slurmctld_internal_ssh_port }}"
-    state: present
-
-# Put the ssh service behind Traefik's TCP proxy.
-- name: Create slurmctld ssh ingress route
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: traefik.containo.us/v1alpha1
-      kind: IngressRouteTCP
-      metadata:
-        name: slurmctldssh-route
-        namespace: "{{ slurm_namespace }}"
-      spec:
-        entryPoints:
-          - slurmctldssh
-        routes:
-          - match: "HostSNI(`*`)"
-            services:
-              - name: slurmctldssh-service
-                namespace: "{{ slurm_namespace }}"
-                port: "{{ slurmctld_external_ssh_port }}"
+        type: LoadBalancer
     state: present
 
 - name: Create slurmctld service

--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -7,28 +7,6 @@
     kind: Namespace
     name: "{{ slurm_namespace }}"
 
-- name: Create slurmctld ssh service
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: v1
-      kind: Service
-      metadata:
-        namespace: "{{ slurm_namespace }}"
-        name: slurmctldssh-service
-        annotations:
-          metallb.universe.tf/loadBalancerIPs: "{{ slurmctld_lb_ip | default(omit) }}"
-      spec:
-        selector:
-          app: slurmctld
-        ports:
-          - name: slurmctldssh
-            protocol: TCP
-            port: "{{ slurmctld_external_ssh_port }}"
-            targetPort: "{{ slurmctld_internal_ssh_port }}"
-        type: LoadBalancer
-    state: present
-
 - name: Create slurmctld service
   kubernetes.core.k8s:
     kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
@@ -48,6 +26,10 @@
             protocol: TCP
             port: "{{ slurmctld_external_port }}"
             targetPort: "{{ slurmctld_internal_port }}"
+          - name: slurmctldssh
+            protocol: TCP
+            port: "{{ slurmctld_external_ssh_port }}"
+            targetPort: "{{ slurmctld_internal_ssh_port }}"
         # Since slurmctld needs to see the source IP from slurm clients, deploy
         # it as a LoadBalancer service with externalTrafficPolicy set to Local.
         externalTrafficPolicy: Local


### PR DESCRIPTION
The slurm controller doesn't need to be placed behind Traefik's TCP proxy. Additionally, it needs to receive the real source IP from slurm clients outside of the Kubernetes cluster, therefore it's now deployed as a LoadBalancer service with `externalTrafficPolicy: Local`.