### PR TITLE
Fix/slurmctld resilience

### DIFF
--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -7,15 +7,37 @@
     kind: Namespace
     name: "{{ slurm_namespace }}"
 
-- name: Create slurmctld service
+# A headless service is required for StatefulSet in order to keep the network
+# identity of pods stable.
+- name: Create the internal-facing slurmctld headless service
   kubernetes.core.k8s:
     kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
     definition:
       apiVersion: v1
       kind: Service
       metadata:
+        name: slurmctld-headless
         namespace: "{{ slurm_namespace }}"
-        name: slurmctld-service
+      spec:
+        selector:
+          app: slurmctld
+        ports:
+          - name: slurmctld
+            protocol: TCP
+            port: "{{ slurmctld_external_port }}"
+            targetPort: "{{ slurmctld_internal_port }}"
+        clusterIP: None
+    state: present
+
+- name: Create the external-facing slurmctld service
+  kubernetes.core.k8s:
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: slurmctld-lb
+        namespace: "{{ slurm_namespace }}"
         annotations:
           metallb.universe.tf/loadBalancerIPs: "{{ slurmctld_lb_ip | default(omit) }}"
       spec:
@@ -36,72 +58,19 @@
         type: LoadBalancer
     state: present
 
-- name: Allocate persistent storage for the Slurm state
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: longhorn-slurm-state
-        namespace: "{{ slurm_namespace }}"
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: longhorn
-        resources:
-          requests:
-            storage: "{{ slurmctld_state_volume_size }}"
-    state: present
-
-- name: Allocate persistent storage for the Slurm configuration directory
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: longhorn-slurm-config
-        namespace: "{{ slurm_namespace }}"
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: longhorn
-        resources:
-          requests:
-            storage: 2Mi
-    state: present
-
-- name: Allocate persistent storage for the Munge configuration directory
-  kubernetes.core.k8s:
-    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
-    definition:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: longhorn-munge-config
-        namespace: "{{ slurm_namespace }}"
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: longhorn
-        resources:
-          requests:
-            storage: 2Mi
-    state: present
-
-- name: Create slurmctld deployment
+- name: Create the slurmctld StatefulSet
   kubernetes.core.k8s:
     kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
     definition:
       apiVersion: apps/v1
-      kind: Deployment
+      kind: StatefulSet
       metadata:
         name: "{{ slurmctld_deployment_name }}"
         namespace: "{{ slurm_namespace }}"
         labels:
           app: slurmctld
       spec:
+        serviceName: slurmctld-headless
         replicas: 1
         selector:
           matchLabels:
@@ -111,7 +80,7 @@
             labels:
               app: slurmctld
           spec:
-            # Use an init container to make sure that slurmctld process can
+            # Use an init container to make sure that the slurmctld process can
             # write to StateSaveLocation.
             initContainers:
               - name: state-dir-chown
@@ -144,16 +113,37 @@
                 ports:
                   - containerPort: "{{ slurmctld_internal_port }}"
                   - containerPort: "{{ slurmctld_internal_ssh_port }}"
-            volumes:
-              - name: slurm-state
-                persistentVolumeClaim:
-                  claimName: longhorn-slurm-state
-              - name: slurm-config
-                persistentVolumeClaim:
-                  claimName: longhorn-slurm-config
-              - name: munge-config
-                persistentVolumeClaim:
-                  claimName: longhorn-munge-config
             imagePullSecrets:
               - name: "{{ slurmctld_image_registry_secret_name | default(omit) }}"
+        volumeClaimTemplates:
+          - metadata:
+              name: slurm-state
+              namespace: "{{ slurm_namespace }}"
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              storageClassName: longhorn
+              resources:
+                requests:
+                  storage: "{{ slurmctld_state_volume_size }}"
+          - metadata:
+              name: slurm-config
+              namespace: "{{ slurm_namespace }}"
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              storageClassName: longhorn
+              resources:
+                requests:
+                  storage: 2Mi
+          - metadata:
+              name: munge-config
+              namespace: "{{ slurm_namespace }}"
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              storageClassName: longhorn
+              resources:
+                requests:
+                  storage: 2Mi
     state: present

--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -42,7 +42,9 @@
           metallb.universe.tf/loadBalancerIPs: "{{ slurmctld_lb_ip | default(omit) }}"
       spec:
         selector:
-          app: slurmctld
+          # Since slurmctld doesn't support more than 1 pod, the service should
+          # target it directly. With StatefulSets, the pod name is predictable.
+          statefulset.kubernetes.io/pod-name: "{{ slurmctld_deployment_name }}-0"
         ports:
           - name: slurmctld
             protocol: TCP

--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -36,6 +36,60 @@
         type: LoadBalancer
     state: present
 
+- name: Allocate persistent storage for the Slurm state
+  kubernetes.core.k8s:
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: longhorn-slurm-state
+        namespace: "{{ slurm_namespace }}"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: "{{ slurmctld_state_volume_size }}"
+    state: present
+
+- name: Allocate persistent storage for the Slurm configuration directory
+  kubernetes.core.k8s:
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: longhorn-slurm-config
+        namespace: "{{ slurm_namespace }}"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 2Mi
+    state: present
+
+- name: Allocate persistent storage for the Munge configuration directory
+  kubernetes.core.k8s:
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: longhorn-munge-config
+        namespace: "{{ slurm_namespace }}"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 2Mi
+    state: present
+
 - name: Create slurmctld deployment
   kubernetes.core.k8s:
     kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
@@ -57,6 +111,19 @@
             labels:
               app: slurmctld
           spec:
+            # Use an init container to make sure that slurmctld process can
+            # write to StateSaveLocation.
+            initContainers:
+              - name: state-dir-chown
+                image: "{{ slurmctld_image_url }}"
+                command:
+                  - chown
+                args:
+                  - "{{ slurmctld_state_volume_owner }}:{{ slurmctld_state_volume_owner }}"
+                  - "{{ slurmctld_state_save_location }}"
+                volumeMounts:
+                  - name: slurm-state
+                    mountPath: "{{ slurmctld_state_save_location }}"
             containers:
               - name: slurmctld
                 image: "{{ slurmctld_image_url }}"
@@ -67,9 +134,26 @@
                   limits:
                     memory: "{{ slurmctld_resources_lim_mem }}"
                     cpu: "{{ slurmctld_resources_lim_cpu }}"
+                volumeMounts:
+                  - name: slurm-state
+                    mountPath: "{{ slurmctld_state_save_location }}"
+                  - name: slurm-config
+                    mountPath: "{{ slurmctld_config_dir }}"
+                  - name: munge-config
+                    mountPath: "{{ slurmctld_munge_dir }}"
                 ports:
                   - containerPort: "{{ slurmctld_internal_port }}"
                   - containerPort: "{{ slurmctld_internal_ssh_port }}"
+            volumes:
+              - name: slurm-state
+                persistentVolumeClaim:
+                  claimName: longhorn-slurm-state
+              - name: slurm-config
+                persistentVolumeClaim:
+                  claimName: longhorn-slurm-config
+              - name: munge-config
+                persistentVolumeClaim:
+                  claimName: longhorn-munge-config
             imagePullSecrets:
               - name: "{{ slurmctld_image_registry_secret_name | default(omit) }}"
     state: present

--- a/ansible/roles/slurm_install/defaults/main.yml
+++ b/ansible/roles/slurm_install/defaults/main.yml
@@ -27,6 +27,10 @@ slurm_munge_secret: "{{ vault_slurm_munge_secret }}"
 # Cluster name for the configuration file
 slurm_cluster_name: slurmcluster
 
+# Value of StateSaveLocation in the configuration file.
+# It should match the variable of the same name in the k8s_slurmctld role.
+slurmctld_state_save_location: /var/spool/slurmctld
+
 # The amount of memory on each node that is *not* intended to be usable by
 # slurm jobs. The usable memory is obtained by subtracting slurm_reserved_mem_mb
 # from the physical memory.

--- a/ansible/roles/slurm_install/templates/slurm.conf.j2
+++ b/ansible/roles/slurm_install/templates/slurm.conf.j2
@@ -20,7 +20,7 @@ SlurmdPidFile=/var/run/slurmd.pid
 SlurmdSpoolDir=/var/spool/slurmd
 SlurmUser=slurm
 #SlurmdUser=root
-StateSaveLocation=/var/spool/slurmctld
+StateSaveLocation={{ slurmctld_state_save_location }}
 SwitchType=switch/none
 TaskPlugin=task/affinity
 #


### PR DESCRIPTION
These changes should allow slurmctld to automatically re-join the cluster if the pod gets rescheduled.

- Configuration directories are now mounted on persistentvolumes.
- The Kubernetes Deployment has been converted into a StatefulSet to guarantee that, in case of a rescheduling, the pod comes back with the same hostname and volumes.