### PR TITLE
Set up sssd in the slurmctld container image

### DIFF
--- a/docker/slurmctld/Dockerfile
+++ b/docker/slurmctld/Dockerfile
@@ -14,6 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         munge \
         openssh-server \
         slurmctld \
+        sssd-ldap \
         sudo \
         supervisor \
     && apt-get clean -y \
@@ -52,6 +53,10 @@ RUN mkdir /run/munge \
 
 # Copy the supervisor definition files.
 COPY etc/supervisor/conf.d/*.conf /etc/supervisor/conf.d/
+
+# Set up sssd to obtain users from the freeipa server.
+COPY etc/sssd/sssd.conf /etc/sssd/sssd.conf
+RUN chmod 600 /etc/sssd/sssd.conf
 
 ENTRYPOINT ["/usr/bin/supervisord"]
 CMD ["--nodaemon"]

--- a/docker/slurmctld/etc/sssd/sssd.conf
+++ b/docker/slurmctld/etc/sssd/sssd.conf
@@ -1,0 +1,9 @@
+[sssd]
+services = nss, pam
+domains = ikim.uk-essen.de
+
+[domain/ikim.uk-essen.de]
+id_provider = ldap
+ldap_uri = ldap://is-3.ikim.uk-essen.de
+ldap_search_base = dc=ikim,dc=uk-essen,dc=de
+cache_credentials = true

--- a/docker/slurmctld/etc/supervisor/conf.d/sssd.conf
+++ b/docker/slurmctld/etc/supervisor/conf.d/sssd.conf
@@ -1,0 +1,5 @@
+[program:sssd]
+command=/usr/sbin/sssd -i --logger=files
+pidfile=/run/sssd.pid
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log


### PR DESCRIPTION
The slurmctld pod must be able to read users from the freeipa server.