### PR TITLE
Add imagePullPolicy to the slurmctld definition.

### DIFF
--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -98,6 +98,7 @@
             containers:
               - name: slurmctld
                 image: "{{ slurmctld_image_url }}"
+                imagePullPolicy: "{{ slurmctld_image_pull_policy | default(omit) }}"
                 resources:
                   requests:
                     memory: "{{ slurmctld_resources_req_mem }}"


### PR DESCRIPTION
Since we aren't currently using versioned tags, the slurmctld pod should be kept up-to-date with builds from the main branch. It's still possible to adopt a more stable approach simply by leaving `slurmctld_image_pull_policy` undefined.