### PR TITLE
Add a Github Action to clean up old images.

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,7 +1,7 @@
 name: Clean up old container images
 
 on:
-  workflow_dispatch:
+  pull_request:
   schedule:
     # Every day at 4:15 am
     - cron: 15 4 * * *

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,6 +1,7 @@
 name: Clean up old container images
 
 on:
+  pull_request:
   schedule:
     # Every day at 4:15 am
     - cron: 15 4 * * *

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,7 +1,6 @@
 name: Clean up old container images
 
 on:
-  pull_request:
   schedule:
     # Every day at 4:15 am
     - cron: 15 4 * * *
@@ -21,4 +20,7 @@ jobs:
           cut-off: One month ago UTC
           account-type: org
           org-name: ${{ github.repository_owner }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # The default Github token cannot be used here as deleting packages
+          # requires a personal access token with the appropriate permissions.
+          # See https://github.com/snok/container-retention-policy#token.
+          # token: ${{ secrets.PAT }}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -23,4 +23,4 @@ jobs:
           # The default Github token cannot be used here as deleting packages
           # requires a personal access token with the appropriate permissions.
           # See https://github.com/snok/container-retention-policy#token.
-          # token: ${{ secrets.PAT }}
+          token: ${{ secrets.PAT_HFRSCHMIDT }}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,7 +1,7 @@
 name: Clean up old container images
 
 on:
-  pull_request:
+  workflow_dispatch:
   schedule:
     # Every day at 4:15 am
     - cron: 15 4 * * *

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,0 +1,24 @@
+name: Clean up old container images
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at 4:15 am
+    - cron: 15 4 * * *
+
+jobs:
+  delete-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete images older than a month built built by pull requests
+        uses: snok/container-retention-policy@v1
+        with:
+          image-names: "*"
+          filter-tags: pr-*
+          cut-off: One month ago UTC
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This Github workflow executes once a day and cleans up images older than a month built by pull requests.