### PR TITLE
Remove the startup option -c for slurmctld

### DIFF
--- a/docker/slurmctld/etc/supervisor/conf.d/slurmctld.conf
+++ b/docker/slurmctld/etc/supervisor/conf.d/slurmctld.conf
@@ -1,5 +1,5 @@
 [program:slurmctld]
-command=/usr/sbin/slurmctld -D -c
+command=/usr/sbin/slurmctld -D -s
 environment=LD_LIBRARY_PATH=/usr/local/lib/
 autorestart=true
 startsecs=3


### PR DESCRIPTION
This should resolve the problem of slurmctld losing the state on restart. To adhere to the upstream systemd service file, -c has been replaced with -s.