### PR TITLE
Relax session limits on slurm worker nodes

### DIFF
--- a/ansible/roles/slurm_install/defaults/main.yml
+++ b/ansible/roles/slurm_install/defaults/main.yml
@@ -50,7 +50,7 @@ slurm_ulimit_memlock_soft: "unlimited"
 slurm_ulimit_memlock_hard: "unlimited"
 slurm_ulimit_nofile_soft: "65536"  # 2^16
 slurm_ulimit_nofile_hard: "131072"  # 2^17
-slurm_ulimit_stack_soft: "unlimited"
+slurm_ulimit_stack_soft: "67108864"  # 64 GiB
 slurm_ulimit_stack_hard: "unlimited"
 
 # The compute node partitions as a list of hashes.

--- a/ansible/roles/slurm_install/defaults/main.yml
+++ b/ansible/roles/slurm_install/defaults/main.yml
@@ -45,6 +45,14 @@ slurm_log_dir: /var/log/slurm
 # See https://slurm.schedmd.com/cons_res.html for details.
 slurm_reserved_mem_mb: 4096
 
+# User limits on worker nodes
+slurm_ulimit_memlock_soft: "unlimited"
+slurm_ulimit_memlock_hard: "unlimited"
+slurm_ulimit_nofile_soft: "65536"  # 2^16
+slurm_ulimit_nofile_hard: "131072"  # 2^17
+slurm_ulimit_stack_soft: "unlimited"
+slurm_ulimit_stack_hard: "unlimited"
+
 # The compute node partitions as a list of hashes.
 # Each hash has the following keys:
 #   name: the partition name as a string

--- a/ansible/roles/slurm_install/tasks/main.yml
+++ b/ansible/roles/slurm_install/tasks/main.yml
@@ -36,6 +36,9 @@
     - ansible.builtin.include_tasks: slurm_worker_install.yml
       when: inventory_hostname in groups[slurm_worker_group_name]
 
+    - ansible.builtin.include_tasks: slurm_worker_limits.yml
+      when: inventory_hostname in groups[slurm_worker_group_name]
+
     - ansible.builtin.include_tasks: slurm_configure.yml
 
     - ansible.builtin.include_tasks: slurm_controller_start.yml

--- a/ansible/roles/slurm_install/tasks/slurm_worker_install.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_worker_install.yml
@@ -16,3 +16,11 @@
       - "slurm-client={{ slurm_version_with_release }}"
     state: present
     update_cache: true
+
+- name: Relax user limits
+  ansible.builtin.template:
+    src: ulimit_slurm_conf.j2
+    dest: /etc/security/limits.d/99-slurm.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/roles/slurm_install/tasks/slurm_worker_install.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_worker_install.yml
@@ -16,11 +16,3 @@
       - "slurm-client={{ slurm_version_with_release }}"
     state: present
     update_cache: true
-
-- name: Relax user limits
-  ansible.builtin.template:
-    src: ulimit_slurm_conf.j2
-    dest: /etc/security/limits.d/99-slurm.conf
-    owner: root
-    group: root
-    mode: 0644

--- a/ansible/roles/slurm_install/tasks/slurm_worker_limits.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_worker_limits.yml
@@ -1,0 +1,8 @@
+---
+- name: Relax user limits
+  ansible.builtin.template:
+    src: ulimit_slurm_conf.j2
+    dest: /etc/security/limits.d/99-slurm.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/roles/slurm_install/templates/ulimit_slurm_conf.j2
+++ b/ansible/roles/slurm_install/templates/ulimit_slurm_conf.j2
@@ -1,0 +1,7 @@
+#<domain> <type> <item>  <value>
+*         soft   memlock {{ slurm_ulimit_memlock_soft }}
+*         hard   memlock {{ slurm_ulimit_memlock_hard }} 
+*         soft   nofile  {{ slurm_ulimit_nofile_soft }}
+*         hard   nofile  {{ slurm_ulimit_nofile_hard }} 
+*         soft   stack   {{ slurm_ulimit_stack_soft }}
+*         hard   stack   {{ slurm_ulimit_stack_hard }} 


### PR DESCRIPTION
Since the upstream systemd service file for `slurmd` specifies relaxed limits for MEMLOCK, NOFILE and STACK, tell slurm to use them instead of propagating limits from the user's environment. Relaxed limits are especially common in gpu-bound jobs.