### PR TITLE
included molecule role paths in molecule_workflow.yml action

### DIFF
--- a/.github/workflows/molecule_workflow.yml
+++ b/.github/workflows/molecule_workflow.yml
@@ -3,9 +3,17 @@ on:
   push:
     branches:
       - main
+    paths:
+    - ansible/roles/miniconda/**
+    - ansible/roles/poetry/**
+    - ansible/roles/proxies/**
   pull_request:
     branches:
       - "*"
+    paths:
+    - ansible/roles/miniconda/**
+    - ansible/roles/poetry/**
+    - ansible/roles/proxies/**
 
 jobs:
   build:

--- a/.github/workflows/molecule_workflow.yml
+++ b/.github/workflows/molecule_workflow.yml
@@ -17,8 +17,11 @@ on:
 
 jobs:
   build:
-    name: Test Roles using MOLECULE
+    name: MOLECULE Role Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        roles: [miniconda, poetry, proxies]
 
     steps:
       - name: Checkout Code
@@ -36,7 +39,8 @@ jobs:
         run: ansible-galaxy collection install community.docker
         
       - name: Test roles that initialized with molecule
-        run: find -type d -name molecule -execdir molecule test \;
+        working-directory: ansible/roles/${{ matrix.roles }}
+        run: molecule test
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/molecule_workflow.yml
+++ b/.github/workflows/molecule_workflow.yml
@@ -44,4 +44,3 @@ jobs:
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
-          

--- a/ansible/roles/proxies/defaults/main.yml
+++ b/ansible/roles/proxies/defaults/main.yml
@@ -1,5 +1,5 @@
 proxy_env_filename: proxy.sh
 http_proxy_host: proxy.example.docker.de
-http_proxy_port: "3128"
+http_proxy_port: "3129"
 http_proxy: "http://{{ http_proxy_host }}:{{ http_proxy_port }}"
 no_proxy: localhost,127.0.0.1

--- a/ansible/roles/proxies/defaults/main.yml
+++ b/ansible/roles/proxies/defaults/main.yml
@@ -1,5 +1,5 @@
 proxy_env_filename: proxy.sh
 http_proxy_host: proxy.example.docker.de
-http_proxy_port: "3129"
+http_proxy_port: "3128"
 http_proxy: "http://{{ http_proxy_host }}:{{ http_proxy_port }}"
 no_proxy: localhost,127.0.0.1


### PR DESCRIPTION
So far,  the molecule test is implemented only for three roles. Hence specifying those paths in molecule_workflow.yml reduces github action load in the future.
