### PR TITLE
Enroll the slurmctld container into IPA on startup

### DIFF
--- a/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
+++ b/ansible/roles/k8s_slurmctld/tasks/install_slurmctld.yml
@@ -7,6 +7,18 @@
     kind: Namespace
     name: "{{ slurm_namespace }}"
 
+- name: Create the ipa admin Secret
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition: "{{ lookup('template', 'ipa_secret.yml.j2') | from_yaml }}"
+
+- name: Create the ipa client ConfigMap
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ rke2_kubeconf_host_path }}{{ rke2_download_kubeconf_file_name }}"
+    definition: "{{ lookup('template', 'ipa_configmap.yml.j2') | from_yaml }}"
+
 # A headless service is required for StatefulSet in order to keep the network
 # identity of pods stable.
 - name: Create the internal-facing slurmctld headless service
@@ -106,6 +118,27 @@
                   limits:
                     memory: "{{ slurmctld_resources_lim_mem }}"
                     cpu: "{{ slurmctld_resources_lim_cpu }}"
+                env:
+                  - name: IPAADMIN_PRINCIPAL
+                    valueFrom:
+                      configMapKeyRef:
+                        name: ipaclient
+                        key: ipaadmin_principal
+                  - name: PRIMARY_IPASERVER
+                    valueFrom:
+                      configMapKeyRef:
+                        name: ipaclient
+                        key: primary_ipaserver
+                  - name: IPACLIENT_DOMAIN
+                    valueFrom:
+                      configMapKeyRef:
+                        name: ipaclient
+                        key: ipaclient_domain
+                  - name: IPACLIENT_REALM
+                    valueFrom:
+                      configMapKeyRef:
+                        name: ipaclient
+                        key: ipaclient_realm
                 volumeMounts:
                   - name: slurm-state
                     mountPath: "{{ slurmctld_state_save_location }}"
@@ -115,9 +148,16 @@
                     mountPath: "{{ slurmctld_munge_dir }}"
                   - name: slurmctld-ssh
                     mountPath: "/home/{{ slurmctld_ssh_user }}/.ssh"
+                  - name: ipaadmin
+                    mountPath: /ipaadmin
+                    readOnly: true
                 ports:
                   - containerPort: "{{ slurmctld_internal_port }}"
                   - containerPort: "{{ slurmctld_internal_ssh_port }}"
+            volumes:
+              - name: ipaadmin
+                secret:
+                  secretName: ipaadmin
             imagePullSecrets:
               - name: "{{ slurmctld_image_registry_secret_name | default(omit) }}"
         volumeClaimTemplates:

--- a/ansible/roles/k8s_slurmctld/templates/ipa_configmap.yml.j2
+++ b/ansible/roles/k8s_slurmctld/templates/ipa_configmap.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ipaclient
+  namespace: {{ slurm_namespace }}
+data:
+  ipaadmin_principal: {{ ipaadmin_principal }}
+  primary_ipaserver: {{ primary_ipaserver }}
+  ipaclient_domain: {{ ipaclient_domain }}
+  ipaclient_realm: {{ ipaclient_realm }}

--- a/ansible/roles/k8s_slurmctld/templates/ipa_secret.yml.j2
+++ b/ansible/roles/k8s_slurmctld/templates/ipa_secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ipaadmin
+  namespace: {{ slurm_namespace }}
+data:
+  password: {{ ipaadmin_password | b64encode }}

--- a/docker/slurmctld/Dockerfile
+++ b/docker/slurmctld/Dockerfile
@@ -17,10 +17,10 @@ ENV TZ=Etc/UTC
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get -y install --no-install-recommends \
+        freeipa-client \
         munge \
         openssh-server \
         slurmctld \
-        sssd-ldap \
         sudo \
         supervisor \
     && apt-get clean -y \
@@ -60,12 +60,12 @@ RUN mkdir /run/munge \
 # Copy the supervisor definition files.
 COPY etc/supervisor/conf.d/*.conf /etc/supervisor/conf.d/
 
-# Set up sssd to obtain users from the freeipa server.
-COPY etc/sssd/sssd.conf /etc/sssd/sssd.conf
-RUN chmod 600 /etc/sssd/sssd.conf
+# Copy the entrypoint script.
+COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/usr/bin/supervisord"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--nodaemon"]
 
+VOLUME ["/ipaadmin"]
 EXPOSE 22
 EXPOSE 6817

--- a/docker/slurmctld/Dockerfile
+++ b/docker/slurmctld/Dockerfile
@@ -53,10 +53,6 @@ RUN mkdir /run/sshd
 RUN mkdir "$SLURM_STATE_SAVE_LOCATION" "$SLURM_LOG_DIR" "$SLURMCTLD_PID_DIR" \
     && chown slurm:slurm "$SLURM_STATE_SAVE_LOCATION" "$SLURM_LOG_DIR" "$SLURMCTLD_PID_DIR"
 
-# Create the MUNGE state directory.
-RUN mkdir /run/munge \
-    && chown munge:munge /run/munge
-
 # Copy the supervisor definition files.
 COPY etc/supervisor/conf.d/*.conf /etc/supervisor/conf.d/
 

--- a/docker/slurmctld/entrypoint.sh
+++ b/docker/slurmctld/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+# NTP should be handled by the host.
+ipa-client-install \
+	--unattended \
+	--force-join \
+	--no-ntp \
+	--no-ssh \
+	--no-sshd \
+	--no-sudo \
+	--principal="$IPAADMIN_PRINCIPAL" \
+	--server="$PRIMARY_IPASERVER" \
+	--domain="$IPACLIENT_DOMAIN" \
+	--realm="$IPACLIENT_REALM" \
+	< /ipaadmin/password
+exec /usr/bin/supervisord "$@"

--- a/docker/slurmctld/etc/sssd/sssd.conf
+++ b/docker/slurmctld/etc/sssd/sssd.conf
@@ -1,9 +1,0 @@
-[sssd]
-services = nss, pam
-domains = ikim.uk-essen.de
-
-[domain/ikim.uk-essen.de]
-id_provider = ldap
-ldap_uri = ldap://is-3.ikim.uk-essen.de
-ldap_search_base = dc=ikim,dc=uk-essen,dc=de
-cache_credentials = true


### PR DESCRIPTION
This allows the slurmctld container to obtain all users and groups including secondary group membership. With the previous lightweight, anonymous ldap client setup, it was difficult to read secondary groups.

Most parameters are collected into a ConfigMap and exposed as environment variables. The password is mounted into a file from a Secret.