### PR TITLE
Have slurm workers start before the controller

### DIFF
--- a/ansible/roles/slurm_install/handlers/main.yml
+++ b/ansible/roles/slurm_install/handlers/main.yml
@@ -1,14 +1,14 @@
 ---
-- name: restart slurmctld
-  become: true
-  community.general.supervisorctl:
-    name: slurmctld
-    state: restarted
-
 - name: restart slurmd
   become: true
   ansible.builtin.systemd:
     name: slurmd
+    state: restarted
+
+- name: restart slurmctld
+  become: true
+  community.general.supervisorctl:
+    name: slurmctld
     state: restarted
 
 - name: restart munge systemd

--- a/ansible/roles/slurm_install/tasks/main.yml
+++ b/ansible/roles/slurm_install/tasks/main.yml
@@ -38,11 +38,11 @@
 
     - ansible.builtin.include_tasks: slurm_configure.yml
 
-    - ansible.builtin.include_tasks: slurm_controller_start.yml
-      when: inventory_hostname in groups[slurm_controller_group_name]
-
     - ansible.builtin.include_tasks: slurm_worker_start.yml
       when: inventory_hostname in groups[slurm_worker_group_name]
+
+    - ansible.builtin.include_tasks: slurm_controller_start.yml
+      when: inventory_hostname in groups[slurm_controller_group_name]
   tags:
     - slurm
     - slurm-node


### PR DESCRIPTION
Slurm worker nodes should be online before the controller. It's not strictly required as the controller polls periodically and eventually everything gets synchronized, but if the controller starts while workers are being (re)deployed, it will mark those nodes as non-responsive for a few minutes.

See https://slurm.schedmd.com/faq.html#add_nodes.