### PR TITLE
Configure apt to prefer the local slurm packages

### DIFF
--- a/ansible/roles/slurm_install/files/99prefer-local-slurm
+++ b/ansible/roles/slurm_install/files/99prefer-local-slurm
@@ -1,0 +1,3 @@
+Package: slurm*
+Pin: origin ""
+Pin-Priority: 900

--- a/ansible/roles/slurm_install/tasks/slurm_worker_prepare.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_worker_prepare.yml
@@ -8,6 +8,14 @@
     repo: "deb [ trusted=yes ] {{ slurm_repo_uri }}/{{ slurm_repo_name }} ./"
     state: present
 
+- name: Configure apt to prefer the custom-built slurm packages
+  ansible.builtin.copy:
+    src: 99prefer-local-slurm
+    dest: /etc/apt/preferences.d/99prefer-local-slurm
+    owner: root
+    group: root
+    mode: 0644
+
 - name: Install the worker daemon and client tools from the custom repository
   ansible.builtin.apt:
     name:


### PR DESCRIPTION
This should prevent apt from including the slurm packages from the ubuntu repositories during a general package upgrade.