### PR TITLE
Add the CUDA PATH component on slurm workers

### DIFF
--- a/ansible/roles/nvidia/tasks/cuda-env.yml
+++ b/ansible/roles/nvidia/tasks/cuda-env.yml
@@ -1,0 +1,7 @@
+- name: Add the cuda compiler to PATH
+  ansible.builtin.copy:
+    src: cuda_env.sh
+    dest: /etc/profile.d/cuda_env.sh
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/roles/nvidia/tasks/main.yml
+++ b/ansible/roles/nvidia/tasks/main.yml
@@ -3,6 +3,11 @@
   - ansible.builtin.include_tasks: nvidia-driver-libs.yml
   tags: nvidia
 
+- name: Add CUDA to PATH
+  block:
+  - ansible.builtin.include_tasks: cuda-env.yml
+  tags: nvidia
+
 - name: Install the Docker runtime
   block:
   - ansible.builtin.include_tasks: nvidia-docker.yml

--- a/ansible/roles/nvidia/tasks/nvidia-driver-libs.yml
+++ b/ansible/roles/nvidia/tasks/nvidia-driver-libs.yml
@@ -14,14 +14,6 @@
     name: "{{ cuda_toolkit_package_name }}"
     state: present
 
-- name: Add the cuda compiler to PATH
-  ansible.builtin.copy:
-    src: cuda_env.sh
-    dest: /etc/profile.d/cuda_env.sh
-    owner: root
-    group: root
-    mode: 0644
-
 - name: Test the cuda installation
   ansible.builtin.command: /usr/local/cuda/bin/nvcc -V
   changed_when: false

--- a/ansible/roles/slurm_install/tasks/slurm_worker_prepare.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_worker_prepare.yml
@@ -25,6 +25,14 @@
     state: present
     update_cache: true
 
+# Even if CUDA is only installed on GPU nodes, PATH and other env vars should be
+# consistent across the cluster, otherwise it can be difficult to submit a job
+# to a GPU node from a non-GPU node.
+- name: Add the CUDA PATH component
+  ansible.builtin.include_role:
+    name: nvidia
+    tasks_from: cuda-env
+
 - name: Relax user limits
   ansible.builtin.template:
     src: ulimit_slurm_conf.j2


### PR DESCRIPTION
Fixes #96

Since slurm jobs use the caller's environment, PATH and other env vars should be consistent across the cluster. To avoid issues when submitting jobs to GPU nodes from non-GPU nodes, the CUDA PATH component is now installed on all slurm workers, even where CUDA is not actually installed.

In terms of code, this avoids duplication at the cost of making the slurm role dependent on the nvidia role.