### PR TITLE
Don't install docker on new gpu node deployments.

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -77,7 +77,6 @@
     - g_nodes
     - proxies
     - ssh_config
-    - docker
     - nvidia
     - miniconda
     - devtools


### PR DESCRIPTION
Even though I haven't removed docker from existing installations, now that we have an `apptainer` role we shouldn't install docker by default.