### PR TITLE
Ignore linter key-order warnings

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -36,6 +36,7 @@ use_default_rules: true
 # This makes linter to fully ignore rules/tags listed below
 skip_list:
   - name[missing]  # This rule flags missing names in blocks, which would result in many redundant names
+  - key-order[tasks]
 
 # Any rule that has the 'opt-in' tag will not be loaded unless its 'id' is
 # mentioned in the enable_list:


### PR DESCRIPTION
The warnings thrown by the linter are currently ignored. We might as well silence them completely.

The positive side of the way we order keys at the moment is that conditional execution is always at the end of a task / play. I like this because it immediately tells me, if there are restrictions in place when this task / play is run. Also having the tags at the end of the task / play makes them easier to find, which is another frequent use case. 

The order suggested by the linter is focused on making it harder to falsely indent keys after for example a block. I have not really experienced this issue before, so I would vote on just keeping our style.