### PR TITLE
Move the zsh installation to a dedicated role

### DIFF
--- a/ansible/roles/devtools/tasks/devtools.yml
+++ b/ansible/roles/devtools/tasks/devtools.yml
@@ -5,7 +5,6 @@
       - python3-venv
       - python3-pip
       - tmux
-      - zsh
       - rename
       - direnv
       - jq

--- a/ansible/roles/proxies/tasks/main.yml
+++ b/ansible/roles/proxies/tasks/main.yml
@@ -9,23 +9,3 @@
   tags:
     - proxy
   become: true
-
-- name: Gather information about installed packages
-  ansible.builtin.package_facts:
-    manager: apt
-  tags:
-    - proxy
-  become: true
-
-- name: Set up proxy variables in zsh
-  ansible.builtin.blockinfile:
-    path: /etc/zsh/zprofile
-    block: "{{ lookup('template', 'zprofile.j2') }}"
-    owner: root
-    group: root
-    create: false
-    state: present
-  when: "'zsh' in ansible_facts.packages"
-  tags:
-    - proxy
-  become: true

--- a/ansible/roles/proxies/templates/zprofile.j2
+++ b/ansible/roles/proxies/templates/zprofile.j2
@@ -1,3 +1,0 @@
-if [[ -r /etc/profile.d/{{ proxy_env_filename }} ]]; then
-	. /etc/profile.d/{{ proxy_env_filename }}
-fi

--- a/ansible/roles/zsh/files/load_bash_profile
+++ b/ansible/roles/zsh/files/load_bash_profile
@@ -1,0 +1,1 @@
+emulate sh -c 'source /etc/profile'

--- a/ansible/roles/zsh/tasks/main.yml
+++ b/ansible/roles/zsh/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Z shell
+  become: true
+  block:
+    - ansible.builtin.include_tasks: zsh.yml
+  tags: zsh

--- a/ansible/roles/zsh/tasks/zsh.yml
+++ b/ansible/roles/zsh/tasks/zsh.yml
@@ -1,0 +1,14 @@
+---
+- name: Install zsh
+  ansible.builtin.apt:
+    name: zsh
+    state: present
+
+- name: Configure Z shell to load the Bash profile on login
+  ansible.builtin.blockinfile:
+    path: /etc/zsh/zprofile
+    block: "{{ lookup('file', 'load_bash_profile') }}"
+    owner: root
+    group: root
+    mode: 0644
+    state: present

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -61,6 +61,7 @@
     - proxies
     - ssh_config
     - security
+    - zsh
     - devtools
     - mambaforge
     - snakemake
@@ -80,6 +81,7 @@
     - g_nodes
     - proxies
     - ssh_config
+    - zsh
     - nvidia
     - mambaforge
     - devtools


### PR DESCRIPTION
Prompted by conda not working for zsh users, but it's a more general solution which [borrows from Arch Linux](https://github.com/archlinux/svntogit-packages/blob/packages/zsh/trunk/zprofile) by loading the bash startup scripts during zsh startup. This allows us to keep all shell startup configuration in one place, i.e. `/etc/profile.d`.

Already deployed on slurm nodes. I've also removed the old contents of `/etc/zsh/zprofile`.