### PR TITLE
Remove slurm controller from ntpclient play

### DIFF
--- a/ansible/roles/ntpclient/tasks/main.yml
+++ b/ansible/roles/ntpclient/tasks/main.yml
@@ -3,4 +3,13 @@
   become: true
   block:
     - ansible.builtin.include_tasks: timesyncd.yml
+      register: task_timesyncd
+  when: ansible_facts['service_mgr'] == "systemd"
+  tags: ntpclient
+
+- name: Notify when ntpclient task is skipped
+  block:
+    - ansible.builtin.debug:
+        msg: "NTP timesyncd setup was skipped because the init system is not systemd."
+  when: task_timesyncd is skipped
   tags: ntpclient

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -4,7 +4,7 @@
   roles:
     - timezone
 
-- hosts: all:!origin
+- hosts: all:!origin:!slurm_controller
   remote_user: ubuntu
   roles:
     - ntpclient

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -4,7 +4,7 @@
   roles:
     - timezone
 
-- hosts: all:!origin:!slurm_controller
+- hosts: all:!origin
   remote_user: ubuntu
   roles:
     - ntpclient


### PR DESCRIPTION
Otherwise the failure to enable and start the systemd unit timesyncd prevents the controller from being targeted in the subsequent plays.