### PR TITLE
Remove the protocol string from the proxy URL

### DIFF
--- a/ansible/roles/proxies/defaults/main.yml
+++ b/ansible/roles/proxies/defaults/main.yml
@@ -1,5 +1,5 @@
 proxy_env_filename: proxy.sh
-http_proxy_host: proxy.example.docker.de
+http_proxy_host: proxy.example.org
 http_proxy_port: "3128"
-http_proxy: "http://{{ http_proxy_host }}:{{ http_proxy_port }}"
+http_proxy: "{{ http_proxy_host }}:{{ http_proxy_port }}"
 no_proxy: localhost,127.0.0.1


### PR DESCRIPTION
[VS Code tunnels](https://code.visualstudio.com/docs/remote/tunnels) don't work on the cluster because our proxy environment variables include _http://_, but VS Code doesn't like that.

apt, curl and conda still work after the change. I ran site.yml on a machine in check mode and didn't get any issues. While this is not a thorough test, it should be enough to avoid a major breakage.