### PR TITLE
Add .yarnrc.yml in /etc/skel

### DIFF
--- a/ansible/roles/user_skel/tasks/main.yml
+++ b/ansible/roles/user_skel/tasks/main.yml
@@ -7,6 +7,14 @@
     - user-home-config
     - docker-user-proxy-config
 
+- name: Configure proxy settings for yarn
+  become: true
+  block:
+    - ansible.builtin.include_tasks: yarn-user-proxy-config.yml
+  tags:
+    - user-home-config
+    - yarn-user-proxy-config
+
 - name: Configure storage for rootless containers
   become: true
   block:

--- a/ansible/roles/user_skel/tasks/yarn-user-proxy-config.yml
+++ b/ansible/roles/user_skel/tasks/yarn-user-proxy-config.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy the yarn proxy configuration
+  ansible.builtin.template:
+    src: yarnrc.yml.j2
+    dest: /etc/skel/.yarnrc.yml
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/roles/user_skel/templates/yarnrc.yml.j2
+++ b/ansible/roles/user_skel/templates/yarnrc.yml.j2
@@ -1,0 +1,2 @@
+httpProxy: "{{ http_proxy }}"
+httpsProxy: "{{ http_proxy }}"


### PR DESCRIPTION
Yarn doesn't use environment variables for the http proxy configuration, therefore we have to create a configuration file in home directories.