### PR TITLE
Base64-encode the Longhorn K8s secrets.

### DIFF
--- a/ansible/roles/k8s_setup_longhorn/tasks/ingress.yml
+++ b/ansible/roles/k8s_setup_longhorn/tasks/ingress.yml
@@ -40,7 +40,7 @@
         name: longhorn-auth-secret
         namespace: default
       data:
-        users: "{{ longhorn_admin_secret }}"
+        users: "{{ longhorn_admin_secret | b64encode }}"
 
 - name: Basic auth longhorn middleware
   kubernetes.core.k8s:

--- a/ansible/roles/k8s_setup_longhorn/tasks/setup.yml
+++ b/ansible/roles/k8s_setup_longhorn/tasks/setup.yml
@@ -70,9 +70,9 @@
         name: "{{ longhorn_backup_cred_secret }}"
         namespace: longhorn-system
       data:
-        AWS_ACCESS_KEY_ID: "{{ longhorn_minio_access_key }}"
-        AWS_SECRET_ACCESS_KEY: "{{ longhorn_minio_secret_key }}"
-        AWS_ENDPOINTS: "{{ longhorn_minio_endpoint }}"
+        AWS_ACCESS_KEY_ID: "{{ longhorn_minio_access_key | b64encode }}"
+        AWS_SECRET_ACCESS_KEY: "{{ longhorn_minio_secret_key | b64encode }}"
+        AWS_ENDPOINTS: "{{ longhorn_minio_endpoint | b64encode }}"
 
 - name: Install longhorn chart
   kubernetes.core.helm:


### PR DESCRIPTION
This requires changing the variables that are currently defined, but it makes things easier in general. For instance, without the base64 encoding in the vars file I can just look at "longhorn_minio_access_key" to find out which key I'm using for longhorn.