### PR TITLE
Add "nosharecache" when the nfs cache is disabled.

### DIFF
--- a/ansible/roles/ipaserver_settings/defaults/main.yml
+++ b/ansible/roles/ipaserver_settings/defaults/main.yml
@@ -1,6 +1,10 @@
 ipa_default_shell: /bin/bash
 
 # List of automount mappings
+# If possible, avoid using a mix of cached and non-cached mounts from the same
+# filesystem. For more information, see the description of the option sharecache
+# in `man nfs`.
+# Example:
 # ipa-automountmaps:
 #   - name: homes
 #     cached: true

--- a/ansible/roles/ipaserver_settings/tasks/create_automountmaps.yml
+++ b/ansible/roles/ipaserver_settings/tasks/create_automountmaps.yml
@@ -54,7 +54,7 @@
       - automountkey-add
       - default
       - "--key \"*\""
-      - "--info \"-{{ 'no' if not mountmap['cached'] }}fsc,fstype=nfs,rw,nfsvers=3 nfs:/dpool/share/{{ mountmap['name'] }}/&\""
+      - "--info \"fstype=nfs,rw,nfsvers=3,{{ 'fsc' if mountmap['cached'] else 'nofsc,nosharecache' }} nfs:/dpool/share/{{ mountmap['name'] }}/&\""
       - "auto.{{ mountmap['name'] }}"
     tty: true
   become: true

--- a/ansible/roles/nfs_client/defaults/main.yml
+++ b/ansible/roles/nfs_client/defaults/main.yml
@@ -18,6 +18,9 @@ autofs_root: /mnt
 
 # List of mountpoints with a local path relative to {{ autofs_root }}
 # The key "cached" controls whether cachefilesd should be enabled for the mountpoint.
+# If possible, avoid using a mix of cached and non-cached mounts from the same
+# filesystem. For more information, see the description of the option sharecache
+# in `man nfs`.
 # Example:
 # autofs_mounts:
 #   - localpath: shared

--- a/ansible/roles/nfs_client/templates/auto.nfs.j2
+++ b/ansible/roles/nfs_client/templates/auto.nfs.j2
@@ -1,3 +1,3 @@
 {% for mount in autofs_mounts %}
-{{ mount['localpath'] }}  -{{ 'fsc,' if mount['cached'] }}{{ mount['options'] }}  {{ mount['server'] }}:{{ mount['remotepath'] }}
+{{ mount['localpath'] }}  -{{ 'fsc' if mount['cached'] else 'nofsc,nosharecache' }}{{ mount['options'] }}  {{ mount['server'] }}:{{ mount['remotepath'] }}
 {% endfor %}


### PR DESCRIPTION
This option is required to have a mix of cached and non-cached mountpoints from the same origin filesystem, although `man nfs` warns against this practice (see the description of the option `sharecache/nosharecache`).