### PR TITLE
Add RBAC rules for freeIPA.

### DIFF
--- a/ansible/roles/ipaserver_settings/tasks/create_rbacrules.yml
+++ b/ansible/roles/ipaserver_settings/tasks/create_rbacrules.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Ensure user managers have the appropriate permissions
+  community.general.ipa_role:
+    cn: "{{ ipaserver_settings_item['rolename'] }}"
+    user: "{{ ipaserver_settings_item['users'] }}"
+    ipa_host: "{{ primary_ipaserver }}"
+    ipa_pass: "{{ ipaadmin_password }}"
+    validate_certs: false
+    state: present
+  loop: "{{ ipa_rbac_roles }}"
+  loop_control:
+    loop_var: ipaserver_settings_item
+  become: true

--- a/ansible/roles/ipaserver_settings/tasks/main.yml
+++ b/ansible/roles/ipaserver_settings/tasks/main.yml
@@ -24,12 +24,20 @@
     - ipa-hostgroups
     - ipa-settings
 
-- name: Include ipa habac rule tasks
+- name: Include ipa hbac rule tasks
   block:
     - ansible.builtin.include_tasks: create_hbacrules.yml
   run_once: true
   tags:
     - ipa-hbacrules
+    - ipa-settings
+
+- name: Include ipa rbac rule tasks
+  block:
+    - ansible.builtin.include_tasks: create_rbacrules.yml
+  run_once: true
+  tags:
+    - ipa-rbacrules
     - ipa-settings
 
 # FIXME: kerberos authentication needed to automatically create the automountmaps


### PR DESCRIPTION
This introduces a task for assigning ipa roles to specific accounts.