### PR TITLE
Install git-lfs

### DIFF
--- a/ansible/roles/devtools/tasks/devtools.yml
+++ b/ansible/roles/devtools/tasks/devtools.yml
@@ -5,6 +5,7 @@
       - python3-venv
       - python3-pip
       - tmux
+      - git-lfs
       - rename
       - direnv
       - jq


### PR DESCRIPTION
Even with the package installed, it needs to be explicitly activated per-user via `git lfs install`.