### PR TITLE
Revert be48c20

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,7 @@
 
 [defaults]
 host_key_checking = False
+roles_path = ./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 remote_tmp = /tmp/.ansible_$USER
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
It is actually needed to support a dedicated playbook directory.