### PR TITLE
Allow customizing the conda directories

### DIFF
--- a/ansible/roles/mambaforge/defaults/main.yml
+++ b/ansible/roles/mambaforge/defaults/main.yml
@@ -1,2 +1,7 @@
-mambaforge_release: "23.3.1-0"
+mambaforge_release: "23.3.1-1"
 mamba_home: /opt/mambaforge
+
+# Define mambaforge_user_env_root to override the default environment locations.
+# Each user will have "{{ mambaforge_user_env_root }}/$USER" as the default
+# environment directory.
+# mambaforge_user_env_root: /var/conda/

--- a/ansible/roles/mambaforge/tasks/mambaforge.yml
+++ b/ansible/roles/mambaforge/tasks/mambaforge.yml
@@ -27,6 +27,15 @@
   register: mambaforge_result
   changed_when: ('All requested packages already installed') not in mambaforge_result['stdout']
 
+- name: Create the custom environment root
+  ansible.builtin.file:
+    path: "{{ mambaforge_user_env_root }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0777"
+  when: mambaforge_user_env_root is defined
+
 - name: Apply system-wide settings
   ansible.builtin.template:
     src: condarc.j2

--- a/ansible/roles/mambaforge/templates/condarc.j2
+++ b/ansible/roles/mambaforge/templates/condarc.j2
@@ -19,7 +19,9 @@ channels:
 envs_dirs:
 - "{{ mambaforge_user_env_root }}/$USER/envs"
 - ~/.conda/envs
+- "{{ mamba_home }}/envs"
 pkgs_dirs:
 - "{{ mambaforge_user_env_root }}/$USER/pkgs"
 - ~/.conda/pkgs
+- "{{ mamba_home }}/pkgs"
 {% endif %}

--- a/ansible/roles/mambaforge/templates/condarc.j2
+++ b/ansible/roles/mambaforge/templates/condarc.j2
@@ -14,3 +14,12 @@ channels:
 - conda-forge
 - bioconda
 - defaults
+
+{% if mambaforge_user_env_root is defined %}
+envs_dirs:
+- "{{ mambaforge_user_env_root }}/$USER/envs"
+- ~/.conda/envs
+pkgs_dirs:
+- "{{ mambaforge_user_env_root }}/$USER/pkgs"
+- ~/.conda/pkgs
+{% endif %}


### PR DESCRIPTION
Moves the default conda directories away from user homes so that they can be placed on the appropriate storage, e.g. local raid or cached nfs.

The new default for the package cache is node-global rather than user-specific.