### PR TITLE
Always install the latest ca-certificates package

### DIFF
--- a/ansible/roles/security/tasks/main.yaml
+++ b/ansible/roles/security/tasks/main.yaml
@@ -23,6 +23,12 @@
       - smartmontools
   tags: admin-tools
 
+- name: Keep the ca-certificates package up-to-date
+  apt:
+    pkg: ca-certificates
+    state: latest
+  tags: ca-certificates
+
 - name: Prevent sleep and hibernation
   ansible.builtin.systemd:
     name: "{{ item }}"


### PR DESCRIPTION
If this package becomes outdated, the client starts reporting certificate errors when connecting to websites.