### PR TITLE
Add directories to the Apptainer bind paths

### DIFF
--- a/ansible/roles/localstorage/tasks/apptainer.yml
+++ b/ansible/roles/localstorage/tasks/apptainer.yml
@@ -1,0 +1,27 @@
+---
+- name: Check the installed packages
+  ansible.builtin.package_facts:
+
+- name: Check the current bind paths in the Apptainer configuration
+  ansible.builtin.command:
+    argv:
+      - apptainer
+      - config
+      - global
+      - --get
+      - bind path
+  changed_when: false
+  register: apptainer_config_get_cmd
+  when: "'apptainer' in ansible_facts['packages']"
+
+- name: Mount the specified path automatically in Apptainer containers
+  ansible.builtin.command:
+    argv:
+      - apptainer
+      - config
+      - global
+      - --set
+      - bind path
+      - "{{ apptainer_bind_path }}"
+  changed_when: apptainer_bind_path not in (apptainer_config_get_cmd['stdout'] | split(','))
+  when: apptainer_config_get_cmd['stdout'] is defined

--- a/ansible/roles/localstorage/tasks/huggingface.yml
+++ b/ansible/roles/localstorage/tasks/huggingface.yml
@@ -73,3 +73,8 @@
     state: started
     enabled: true
     daemon_reload: true
+
+- name: If Apptainer is installed, mount the cache dir in containers
+  vars:
+    apptainer_bind_path: "{{ localstorage_huggingface_cache_root }}"
+  ansible.builtin.include_tasks: apptainer.yml

--- a/ansible/roles/localstorage/tasks/tmpdir.yml
+++ b/ansible/roles/localstorage/tasks/tmpdir.yml
@@ -22,3 +22,8 @@
     owner: "{{ localstorage_tmpdir_attrs['owner'] }}"
     group: "{{ localstorage_tmpdir_attrs['group'] }}"
     mode: "{{ localstorage_tmpdir_attrs['mode'] }}"
+
+- name: If Apptainer is installed, mount TMPDIR in containers
+  vars:
+    apptainer_bind_path: "{{ localstorage_tmpdir }}"
+  ansible.builtin.include_tasks: apptainer.yml


### PR DESCRIPTION
During the setup of TMPDIR and the huggingface cache dir, if Apptainer is installed, the directories are configured to be automatically mounted in containers.