### PR TITLE
fix: upper bound for estimated memory requirements

### DIFF
--- a/ansible/roles/snakemake/templates/profile.yaml.j2
+++ b/ansible/roles/snakemake/templates/profile.yaml.j2
@@ -3,3 +3,6 @@ slurm: true
 {% endif %}
 use-conda: true
 latency-wait: 60
+default-resources:
+  mem_mb: min(max(2*input.size_mb, 1000), 30000)
+  tmpdir: system_tmpdir


### PR DESCRIPTION
Above the given threshold, it is very unlikely that the step really loads all input files into memory.