### PR TITLE
Add the role ssh_hostkey

### DIFF
--- a/ansible/roles/ssh_hostkey/defaults/main.yml
+++ b/ansible/roles/ssh_hostkey/defaults/main.yml
@@ -1,0 +1,4 @@
+ssh_hostkey_filename: ssh_host_key_custom
+
+ssh_hostkey_private_key_contents: "{{ vault_ssh_hostkey_private_key_contents }}"
+ssh_hostkey_public_key_contents: "{{ vault_ssh_hostkey_public_key_contents }}"

--- a/ansible/roles/ssh_hostkey/handlers/main.yml
+++ b/ansible/roles/ssh_hostkey/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload sshd
+  become: true
+  ansible.builtin.systemd:
+    name: sshd
+    state: reloaded

--- a/ansible/roles/ssh_hostkey/tasks/main.yml
+++ b/ansible/roles/ssh_hostkey/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Set up the ssh host key
+  become: true
+  block:
+    - ansible.builtin.include_tasks: ssh-hostkey.yml
+  tags: ssh-hostkey

--- a/ansible/roles/ssh_hostkey/tasks/ssh-hostkey.yml
+++ b/ansible/roles/ssh_hostkey/tasks/ssh-hostkey.yml
@@ -1,0 +1,27 @@
+---
+- name: Copy the private key
+  ansible.builtin.template:
+    src: key.j2
+    dest: "/etc/ssh/{{ ssh_hostkey_filename }}"
+    owner: root
+    group: root
+    mode: "0600"
+  notify: Reload sshd
+
+- name: Copy the public key
+  ansible.builtin.template:
+    src: key.pub.j2
+    dest: "/etc/ssh/{{ ssh_hostkey_filename }}.pub"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload sshd
+
+- name: Instruct sshd to serve the key
+  ansible.builtin.template:
+    src: 00-hostkey.conf.j2
+    dest: /etc/ssh/sshd_config.d/00-hostkey.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload sshd

--- a/ansible/roles/ssh_hostkey/templates/00-hostkey.conf.j2
+++ b/ansible/roles/ssh_hostkey/templates/00-hostkey.conf.j2
@@ -1,0 +1,1 @@
+HostKey /etc/ssh/{{ ssh_hostkey_filename }}

--- a/ansible/roles/ssh_hostkey/templates/key.j2
+++ b/ansible/roles/ssh_hostkey/templates/key.j2
@@ -1,0 +1,1 @@
+{{ ssh_hostkey_private_key_contents }}

--- a/ansible/roles/ssh_hostkey/templates/key.pub.j2
+++ b/ansible/roles/ssh_hostkey/templates/key.pub.j2
@@ -1,0 +1,1 @@
+{{ ssh_hostkey_public_key_contents }}

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -134,6 +134,10 @@
     - nfs_shares
     - user_skel
 
+- hosts: dns_roundrobin
+  environment: "{{ proxy_env | default({}) }}"
+  roles:
+    - ssh_hostkey
 
 - hosts: rke_k8s_cluster
   gather_facts: true


### PR DESCRIPTION
This role configures the ssh host key from a variable. Useful for hosts participating in a DNS round-robin setup.