### PR TITLE
Mark the slurm packages as held in apt

### DIFF
--- a/ansible/roles/custom_pkgs/defaults/main.yml
+++ b/ansible/roles/custom_pkgs/defaults/main.yml
@@ -1,0 +1,5 @@
+# The paths of the deb packages to install on the target host.
+# If custom_pkgs_archive is defined, the items in custom_pkgs_debs are
+# interpreted as paths in the archive.
+custom_pkgs_debs: []
+# custom_pkgs_archive:

--- a/ansible/roles/custom_pkgs/tasks/extract.yml
+++ b/ansible/roles/custom_pkgs/tasks/extract.yml
@@ -1,0 +1,7 @@
+---
+- name: Extract the archive
+  ansible.builtin.unarchive:
+    src: "{{ custom_pkgs_archive }}"
+    dest: "{{ custom_pkgs_prefix }}"
+    remote_src: true
+  when: custom_pkgs_archive is defined

--- a/ansible/roles/custom_pkgs/tasks/installdeb.yml
+++ b/ansible/roles/custom_pkgs/tasks/installdeb.yml
@@ -1,0 +1,26 @@
+---
+- name: Obtain the package name
+  ansible.builtin.command:
+    argv:
+      - dpkg-deb
+      - --field
+      - "{{ custom_pkgs_path }}"
+      - Package
+  changed_when: false
+  register: custom_pkgs_dpkg_deb
+
+- name: Install the package
+  ansible.builtin.apt:
+    deb: "{{ custom_pkgs_path }}"
+    allow_change_held_packages: true
+    state: present
+
+- name: Prevent the package manager from upgrading the package from a different source
+  ansible.builtin.command:
+    argv:
+      - apt-mark
+      - hold
+      - "{{ custom_pkgs_dpkg_deb['stdout'] }}"
+  register: custom_pkgs_apt_mark
+  changed_when: custom_pkgs_apt_mark['stdout'] == (custom_pkgs_dpkg_deb['stdout'] ~ ' set on hold.')
+  when: custom_pkgs_dpkg_deb['stdout'] is defined

--- a/ansible/roles/custom_pkgs/tasks/main.yml
+++ b/ansible/roles/custom_pkgs/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Extract the package archive
+  block:
+    - ansible.builtin.include_tasks: extract.yml
+  tags:
+    - custom-pkgs
+    - custom-pkgs-extract
+
+- name: Install the deb packages
+  block:
+    - ansible.builtin.include_tasks: installdeb.yml
+      vars:
+        custom_pkgs_path: "{{ (custom_pkgs_prefix, custom_pkgs_item) | path_join }}"
+      loop: "{{ custom_pkgs_debs }}"
+      loop_control:
+        loop_var: custom_pkgs_item
+  tags:
+    - custom-pkgs
+    - custom-pkgs-install

--- a/ansible/roles/custom_pkgs/vars/main.yml
+++ b/ansible/roles/custom_pkgs/vars/main.yml
@@ -1,0 +1,1 @@
+custom_pkgs_prefix: "{{ (custom_pkgs_archive is defined) | ternary('/tmp', '')  }}"

--- a/ansible/roles/slurm_install/tasks/slurm_pam_adopt.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_pam_adopt.yml
@@ -1,19 +1,12 @@
 ---
-- name: Download the deb packages
-  ansible.builtin.unarchive:
-    src: "{{ slurm_worker_debs_url }}"
-    dest: /tmp
-    remote_src: true
-
 - name: Install packages for pam_slurm_adopt
-  ansible.builtin.apt:
-    deb: "/tmp/{{ slurm_install_item }}"
-    state: present
-  loop:
-    - "{{ slurm_worker_debs_dirname }}/libslurm37_{{ slurm_worker_debs_tag }}_amd64.deb"
-    - "{{ slurm_worker_debs_dirname }}/libpam-slurm-adopt_{{ slurm_worker_debs_tag }}_amd64.deb"
-  loop_control:
-    loop_var: slurm_install_item
+  vars:
+    custom_pkgs_archive: "{{ slurm_worker_debs_url }}"
+    custom_pkgs_debs:
+      - "{{ slurm_worker_debs_dirname }}/libslurm37_{{ slurm_worker_debs_tag }}_amd64.deb"
+      - "{{ slurm_worker_debs_dirname }}/libpam-slurm-adopt_{{ slurm_worker_debs_tag }}_amd64.deb"
+  ansible.builtin.include_role:
+    name: custom_pkgs
 
 - name: Mask the systemd-logind service as instructed by the pam_slurm_adopt guide
   ansible.builtin.systemd:

--- a/ansible/roles/slurm_install/tasks/slurm_worker_install.yml
+++ b/ansible/roles/slurm_install/tasks/slurm_worker_install.yml
@@ -5,27 +5,12 @@
     state: absent
   when: slurm_upgrade
 
-- name: Configure apt to prefer the custom-built slurm packages
-  ansible.builtin.copy:
-    src: 99prefer-local-slurm
-    dest: /etc/apt/preferences.d/99prefer-local-slurm
-    owner: root
-    group: root
-    mode: "0644"
-
-- name: Download the deb packages
-  ansible.builtin.unarchive:
-    src: "{{ slurm_worker_debs_url }}"
-    dest: /tmp
-    remote_src: true
-
 - name: Install the worker daemon and client tools
-  ansible.builtin.apt:
-    deb: "/tmp/{{ slurm_install_item }}"
-    state: present
-  loop:
-    - "{{ slurm_worker_debs_dirname }}/slurm-wlm-basic-plugins_{{ slurm_worker_debs_tag }}_amd64.deb"
-    - "{{ slurm_worker_debs_dirname }}/slurm-client_{{ slurm_worker_debs_tag }}_amd64.deb"
-    - "{{ slurm_worker_debs_dirname }}/slurmd_{{ slurm_worker_debs_tag }}_amd64.deb"
-  loop_control:
-    loop_var: slurm_install_item
+  vars:
+    custom_pkgs_archive: "{{ slurm_worker_debs_url }}"
+    custom_pkgs_debs:
+      - "{{ slurm_worker_debs_dirname }}/slurm-wlm-basic-plugins_{{ slurm_worker_debs_tag }}_amd64.deb"
+      - "{{ slurm_worker_debs_dirname }}/slurm-client_{{ slurm_worker_debs_tag }}_amd64.deb"
+      - "{{ slurm_worker_debs_dirname }}/slurmd_{{ slurm_worker_debs_tag }}_amd64.deb"
+  ansible.builtin.include_role:
+    name: custom_pkgs


### PR DESCRIPTION
This prevents the package manager from replacing the custom-built slurm packages with the ones from Ubuntu repo.