### PR TITLE
Fix the services regex for /etc/sssd/sssd.conf

### DIFF
--- a/ansible/roles/ipaclient_postinstall/tasks/sssd_socket_activation.yml
+++ b/ansible/roles/ipaclient_postinstall/tasks/sssd_socket_activation.yml
@@ -1,7 +1,7 @@
-- name: Modify sssd.conf to not block sssd service socket activation
+- name: Modify sssd.conf to avoid blocking the sssd responder sockets
   ansible.builtin.lineinfile:
     path: /etc/sssd/sssd.conf
     state: absent
-    regexp: '^services = nss, pam, ssh, sudo$'
+    regexp: '^services ='
   notify: restart sssd service
   become: true


### PR DESCRIPTION
There's no need for the regex to match specific services since all of them should be removed anyway.