### PR TITLE
Add workarounds for cachefilesd and autofs

### DIFF
--- a/ansible/roles/nfs_client/handlers/main.yml
+++ b/ansible/roles/nfs_client/handlers/main.yml
@@ -1,12 +1,12 @@
 ---
-- name: reload autofs
-  become: true
-  ansible.builtin.systemd:
-    name: autofs
-    state: reloaded
-
 - name: restart cachefilesd
   become: true
   ansible.builtin.systemd:
     name: cachefilesd
     state: restarted
+
+- name: reload autofs
+  become: true
+  ansible.builtin.systemd:
+    name: autofs
+    state: reloaded

--- a/ansible/roles/nfs_client/tasks/cachefilesd.yml
+++ b/ansible/roles/nfs_client/tasks/cachefilesd.yml
@@ -3,10 +3,27 @@
     name: cachefilesd
     state: present
 
-- name: Make sure the cachefilesd service is running
+- name: Create a config directory for the cachefilesd service
+  ansible.builtin.file:
+    path: /etc/systemd/system/cachefilesd.service.d
+    owner: root
+    group: root
+    mode: "0755"
+    state: directory
+
+- name: Configure cachefilesd restart automatically on failure to avoid issues during startup
+  ansible.builtin.template:
+    src: restart-on-failure.conf.j2
+    dest: /etc/systemd/system/cachefilesd.service.d/restart-on-failure.conf
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Start the cachefilesd service
   ansible.builtin.systemd:
     name: cachefilesd
     enabled: true
+    daemon_reload: true
     state: started
 
 - name: Create the cache directory

--- a/ansible/roles/nfs_client/tasks/install_autofs.yml
+++ b/ansible/roles/nfs_client/tasks/install_autofs.yml
@@ -6,8 +6,25 @@
       - autofs
     state: present
 
+- name: Create a config directory for the autofs service
+  ansible.builtin.file:
+    path: /etc/systemd/system/autofs.service.d
+    owner: root
+    group: root
+    mode: "0755"
+    state: directory
+
+- name: Configure autofs to delay the startup so that sssd has more time to launch fully
+  ansible.builtin.template:
+    src: delay-startup.conf.j2
+    dest: /etc/systemd/system/autofs.service.d/delay-startup.conf
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Make sure autofs is running
   ansible.builtin.systemd:
     name: autofs
     enabled: true
+    daemon_reload: true
     state: started

--- a/ansible/roles/nfs_client/tasks/main.yml
+++ b/ansible/roles/nfs_client/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Configure cachefilesd
+  become: true
+  block:
+    - ansible.builtin.include_tasks: cachefilesd.yml
+  tags: nfs-client
+
 - name: Install autofs
   become: true
   block:
@@ -17,14 +23,4 @@
   block:
     - ansible.builtin.include_tasks: ipa_automount.yml
   when: ipa_automounts_enabled
-  tags: nfs-client
-
-- name: Flush any autofs handlers before setting up cachefilesd
-  ansible.builtin.meta: flush_handlers
-  tags: nfs-client
-
-- name: Configure cachefilesd
-  become: true
-  block:
-    - ansible.builtin.include_tasks: cachefilesd.yml
   tags: nfs-client

--- a/ansible/roles/nfs_client/templates/delay-startup.conf.j2
+++ b/ansible/roles/nfs_client/templates/delay-startup.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/sleep 10

--- a/ansible/roles/nfs_client/templates/restart-on-failure.conf.j2
+++ b/ansible/roles/nfs_client/templates/restart-on-failure.conf.j2
@@ -1,0 +1,3 @@
+[Service]
+Restart=on-failure
+RestartSec=3


### PR DESCRIPTION
Autofs sometimes reports a false success with the message setautomntent: lookup(sss): setautomntent: Connection refused This might be caused by starting up too quickly after sssd. As a workaround, a 10-second startup delay is introduced.

Cachefilesd frequently fails on startup, but succeeds on a manual attempt later. As a workaround, the service is now configured to retry automatically.