### PR TITLE
Increase the kill wait time

### DIFF
--- a/ansible/roles/slurm_install/templates/slurm.conf.j2
+++ b/ansible/roles/slurm_install/templates/slurm.conf.j2
@@ -26,11 +26,11 @@ TaskPlugin=task/affinity,task/cgroup
 #
 #
 # TIMERS
-KillWait=120
+KillWait=300
 #MinJobAge=300
 #SlurmctldTimeout=120
 #SlurmdTimeout=300
-UnkillableStepTimeout=120
+UnkillableStepTimeout=300
 #
 #
 # SCHEDULING


### PR DESCRIPTION
To allow large jobs to be cancelled gracefully, both the KillWait parameter and UnkillableStepTimeout have been increased to 5 minutes.