### PR TITLE
fix: simplify and improve snakemake profile, relying on snakemake 8.6.0

### DIFF
--- a/ansible/roles/snakemake/templates/profile.v8+.yaml.j2
+++ b/ansible/roles/snakemake/templates/profile.v8+.yaml.j2
@@ -1,8 +1,3 @@
-__use_yte__: True
-
-__definitions__:
-  - import os
-
 {% if inventory_hostname in groups[slurm_worker_group_name] %}
 executor: slurm
 resources:
@@ -20,7 +15,5 @@ software-deployment-method:
 latency-wait: 60
 # enforce using local work directories instead of directly running in NFS
 default-storage-provider: fs
-?if "SLURM_JOB_ID" in os.environ:
-    local-storage-prefix: /local/work/$USER/slurm-job-$SLURM_JOB_ID/snakemake-scratch
-?else:
-    local-storage-prefix: /local/work/$USER/snakemake-scratch
+local-storage-prefix: /local/work/$USER/snakemake-scratch
+remote-job-local-storage-prefix: /local/work/$USER/slurm-job-\$SLURM_JOB_ID/snakemake-scratch


### PR DESCRIPTION
Requires snakemake 8.6.0 to be released and propagated to anaconda.org: done!