### PR TITLE
playbooks/usermgmt: Allow IPA setup host override

### DIFF
--- a/ansible/playbooks/usermgmt/create-users-groups.yml
+++ b/ansible/playbooks/usermgmt/create-users-groups.yml
@@ -15,7 +15,8 @@
       loop: "{{ lookup('fileglob', groupglob, wantlist=True) }}"
       when: groupglob is defined
 
-- hosts: managed_cluster
+# FIXME: We run this locally via ipa_host_override for now. Needs cleanup.
+- hosts: {{ ipa_host_override | default('managed_cluster') }}
   run_once: true
   gather_facts: false
   vars:


### PR DESCRIPTION
Run `tasks/add-user-ipa.yml`, `tasks/add-group-ipa.yml` optionally on a custom host (a.k.a, localhost).
(NB: This all needs some cleanup and this change is just supposed to be a minimal/temporary measure.)