### PR TITLE
playbooks/usermgmt: Add new keys via ikimuseradd

### DIFF
--- a/ansible/playbooks/usermgmt/tasks/add-user-bastion.yml
+++ b/ansible/playbooks/usermgmt/tasks/add-user-bastion.yml
@@ -23,7 +23,9 @@
       - sudo
       - /root/bin/ikimuseradd.sh
       - "{{ usermgmt_tempfile['path'] }}"
-    creates: "/home/{{ item['value']['username'] }}"
+    # As of 2024-10, ikimuseradd.sh also handles adding new ssh keys for
+    # existing users, so always run it, even if /home/user already exists.
+    # creates: "/home/{{ item['value']['username'] }}"
   when: usermgmt_tempfile['path'] is defined
 
 - name: Delete the temp file


### PR DESCRIPTION
`ikimuseradd.sh` on the bastion nodes handles multiple keys now and does some more validation.
Later on, we should factor out the key handling into a separate step/script, though, to make it cleaner/more robust.